### PR TITLE
배송 도메인 기본 CRUD api 구현

### DIFF
--- a/src/main/java/com/project/doubleshop/domain/category/service/CategoryService.java
+++ b/src/main/java/com/project/doubleshop/domain/category/service/CategoryService.java
@@ -31,7 +31,7 @@ public class CategoryService {
 		if (saveCategory(category)) {
 			return category;
 		} else {
-			throw new DataNotFoundException(String.format("inserted category id %d not found", category.getId()));
+			throw new DataNotFoundException(String.format("Inserted category id %d not found", category.getId()));
 		}
 	}
 

--- a/src/main/java/com/project/doubleshop/domain/common/Status.java
+++ b/src/main/java/com/project/doubleshop/domain/common/Status.java
@@ -22,7 +22,7 @@ public enum Status {
 			case TO_BE_DELETED_CODE:
 				return Status.TO_BE_DELETED;
 			default:
-				throw new AssertionError(String.format("unknown Status value : %d", value));
+				throw new AssertionError(String.format("Unknown Status value : %d", value));
 		}
 	}
 

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/Delivery.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/Delivery.java
@@ -30,6 +30,9 @@ public class Delivery {
 	// 배송 수정일
 	private LocalDateTime updateTime;
 
+	// 배송 상태
+	private DeliveryStatus deliveryStatus;
+
 	// 상태
 	private Status status;
 

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/Delivery.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/Delivery.java
@@ -1,5 +1,9 @@
 package com.project.doubleshop.domain.delivery.entity;
 
+import java.time.LocalDateTime;
+
+import com.project.doubleshop.domain.common.Status;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,5 +23,11 @@ public class Delivery {
 
 	// 배송 메모
 	private String memo;
+
+	// 상태
+	private Status status;
+
+	// 상태 업데이트 시간
+	private LocalDateTime statusUpdateTime;
 }
 

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/Delivery.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/Delivery.java
@@ -35,5 +35,11 @@ public class Delivery {
 
 	// 상태 업데이트 시간
 	private LocalDateTime statusUpdateTime;
+
+	// 배송정책 fk
+	private Long deliveryPolicyId;
+
+	// 배송기사 fk
+	private Long deliveryDriverId;
 }
 

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/Delivery.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/Delivery.java
@@ -3,6 +3,7 @@ package com.project.doubleshop.domain.delivery.entity;
 import java.time.LocalDateTime;
 
 import com.project.doubleshop.domain.common.Status;
+import com.project.doubleshop.web.delivery.dto.DeliveryForm;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -44,5 +45,16 @@ public class Delivery {
 
 	// 배송기사 fk
 	private Long deliveryDriverId;
+
+	public static Delivery convertToDelivery(DeliveryForm form) {
+		return Delivery.builder()
+			.id(form.getId())
+			.waybillNumber(form.getWaybillNumber())
+			.memo(form.getMemo())
+			.deliveryStatus(form.getDeliveryStatus())
+			.deliveryPolicyId(form.getDeliveryPolicyId())
+			.deliveryDriverId(form.getDeliveryDriverId())
+			.build();
+	}
 }
 

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/Delivery.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/Delivery.java
@@ -24,6 +24,12 @@ public class Delivery {
 	// 배송 메모
 	private String memo;
 
+	// 배송 등록일
+	private LocalDateTime createTime;
+
+	// 배송 수정일
+	private LocalDateTime updateTime;
+
 	// 상태
 	private Status status;
 

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/Delivery.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/Delivery.java
@@ -1,0 +1,23 @@
+package com.project.doubleshop.domain.delivery.entity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class Delivery {
+	// 배송 pk
+	private Long id;
+
+	// 운송장 번호
+	private String waybillNumber;
+
+	// 배송 메모
+	private String memo;
+}
+

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/DeliveryDriver.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/DeliveryDriver.java
@@ -1,0 +1,38 @@
+package com.project.doubleshop.domain.delivery.entity;
+
+import java.time.LocalDateTime;
+
+import com.project.doubleshop.domain.common.Status;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class DeliveryDriver {
+	// 배송기사 pk
+	private Long id;
+
+	// 이름
+	private String name;
+
+	// 핸드폰 번호
+	private String phone;
+
+	// 등록일
+	private LocalDateTime createTime;
+
+	// 수정일
+	private LocalDateTime updateTime;
+
+	// 상태
+	private Status status;
+
+	// 상태 변경시간
+	private LocalDateTime statusUpdateTime;
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/DeliveryDriver.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/DeliveryDriver.java
@@ -3,6 +3,7 @@ package com.project.doubleshop.domain.delivery.entity;
 import java.time.LocalDateTime;
 
 import com.project.doubleshop.domain.common.Status;
+import com.project.doubleshop.web.delivery.dto.DeliveryDriverForm;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -35,4 +36,12 @@ public class DeliveryDriver {
 
 	// 상태 변경시간
 	private LocalDateTime statusUpdateTime;
+
+	public static DeliveryDriver convertToDeliveryDriver(DeliveryDriverForm form) {
+		return DeliveryDriver.builder()
+			.id(form.getId())
+			.name(form.getName())
+			.phone(form.getPhone())
+			.build();
+	}
 }

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/DeliveryPolicy.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/DeliveryPolicy.java
@@ -1,0 +1,34 @@
+package com.project.doubleshop.domain.delivery.entity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class DeliveryPolicy {
+	// 배송 정책 pk
+	private Long id;
+
+	// 배송 정책 이름
+	private String name;
+
+	// 배송사
+	private String company;
+
+	// 배송비 적용 정책
+	private FeePolicy feePolicy;
+
+	// 배송비 지불방식
+	private FeeMethod feeMethod;
+
+	// 배송비
+	private int feePrice;
+
+	// 산간도서지역비용
+	private int islandMountainousFee;
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/DeliveryPolicy.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/DeliveryPolicy.java
@@ -1,5 +1,9 @@
 package com.project.doubleshop.domain.delivery.entity;
 
+import java.time.LocalDateTime;
+
+import com.project.doubleshop.domain.common.Status;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,4 +35,10 @@ public class DeliveryPolicy {
 
 	// 산간도서지역비용
 	private int islandMountainousFee;
+
+	// 상태
+	private Status status;
+
+	// 상태 업데이트 시간
+	private LocalDateTime statusUpdateTime;
 }

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/DeliveryPolicy.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/DeliveryPolicy.java
@@ -3,6 +3,7 @@ package com.project.doubleshop.domain.delivery.entity;
 import java.time.LocalDateTime;
 
 import com.project.doubleshop.domain.common.Status;
+import com.project.doubleshop.web.delivery.dto.DeliveryPolicyForm;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -41,4 +42,16 @@ public class DeliveryPolicy {
 
 	// 상태 업데이트 시간
 	private LocalDateTime statusUpdateTime;
+
+	public static DeliveryPolicy convertToDeliveryPolicy(DeliveryPolicyForm form) {
+		return DeliveryPolicy.builder()
+			.id(form.getId())
+			.name(form.getName())
+			.company(form.getCompany())
+			.feePolicy(form.getFeePolicy())
+			.feeMethod(form.getFeeMethod())
+			.feePrice(form.getFeePrice())
+			.islandMountainousFee(form.getIslandMountainousFee())
+			.build();
+	}
 }

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/DeliveryStatus.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/DeliveryStatus.java
@@ -1,0 +1,38 @@
+package com.project.doubleshop.domain.delivery.entity;
+
+import static com.project.doubleshop.domain.delivery.entity.DeliveryStatusConstant.*;
+
+public enum DeliveryStatus {
+	PRODUCT_PREPARATION(PRODUCT_PREPARATION_CODE),
+	DELIVERY_PREPARATION(DELIVERY_PREPARATION_CODE),
+	DELIVERY_ON_HOLD(DELIVERY_ON_HOLD_CODE),
+	DELIVERY_ONGOING(DELIVERY_ONGOING_CODE),
+	DELIVERY_COMPLETE(DELIVERY_COMPLETE_CODE);
+
+	private final int i;
+
+	DeliveryStatus(int i) {
+		this.i = i;
+	}
+
+	public static DeliveryStatus of(int value) {
+		switch (value) {
+			case PRODUCT_PREPARATION_CODE:
+				return DeliveryStatus.PRODUCT_PREPARATION;
+			case DELIVERY_PREPARATION_CODE:
+				return DeliveryStatus.DELIVERY_PREPARATION;
+			case DELIVERY_ON_HOLD_CODE:
+				return DeliveryStatus.DELIVERY_ON_HOLD;
+			case DELIVERY_ONGOING_CODE:
+				return DeliveryStatus.DELIVERY_ONGOING;
+			case DELIVERY_COMPLETE_CODE:
+				return DeliveryStatus.DELIVERY_COMPLETE;
+			default:
+				throw new AssertionError(String.format("Unknown DeliveryStatus value : %d", value));
+		}
+	}
+
+	public int getValue() {
+		return i;
+	}
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/DeliveryStatusConstant.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/DeliveryStatusConstant.java
@@ -1,0 +1,9 @@
+package com.project.doubleshop.domain.delivery.entity;
+
+public class DeliveryStatusConstant {
+	public static final int PRODUCT_PREPARATION_CODE = 4001;
+	public static final int DELIVERY_PREPARATION_CODE = 4002;
+	public static final int DELIVERY_ON_HOLD_CODE = 4003;
+	public static final int DELIVERY_ONGOING_CODE = 4004;
+	public static final int DELIVERY_COMPLETE_CODE = 4005;
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/DeliveryStatusTypeHandler.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/DeliveryStatusTypeHandler.java
@@ -1,0 +1,32 @@
+package com.project.doubleshop.domain.delivery.entity;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+
+public class DeliveryStatusTypeHandler extends BaseTypeHandler<DeliveryStatus> {
+	@Override
+	public void setNonNullParameter(PreparedStatement ps, int i, DeliveryStatus parameter, JdbcType jdbcType) throws
+		SQLException {
+		ps.setInt(i, parameter.getValue());
+	}
+
+	@Override
+	public DeliveryStatus getNullableResult(ResultSet rs, String columnName) throws SQLException {
+		return DeliveryStatus.of(rs.getInt(columnName));
+	}
+
+	@Override
+	public DeliveryStatus getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+		return DeliveryStatus.of(rs.getInt(columnIndex));
+	}
+
+	@Override
+	public DeliveryStatus getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+		return DeliveryStatus.of(cs.getInt(columnIndex));
+	}
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/FeeMethod.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/FeeMethod.java
@@ -1,0 +1,34 @@
+package com.project.doubleshop.domain.delivery.entity;
+
+import static com.project.doubleshop.domain.delivery.entity.FeeMethodConstant.*;
+
+public enum FeeMethod {
+	PREPAID(PREPAID_CODE),
+	POSTPAID(POSTPAID_CODE);
+
+	private final int i;
+
+	FeeMethod(int i) {
+		this.i = i;
+	}
+
+	public static FeeMethod of(int value) {
+		switch (value) {
+			case PREPAID_CODE:
+				return FeeMethod.PREPAID;
+			case POSTPAID_CODE:
+				return FeeMethod.POSTPAID;
+			default:
+				throw new AssertionError(String.format("Unknown FeeMethod value : %d", value));
+		}
+	}
+
+	public int getValue() {
+		return i;
+	}
+
+	@Override
+	public String toString() {
+		return this.name();
+	}
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/FeeMethod.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/FeeMethod.java
@@ -23,6 +23,15 @@ public enum FeeMethod {
 		}
 	}
 
+	public static FeeMethod of(String value) {
+		for (FeeMethod feeMethod : FeeMethod.values()) {
+			if (feeMethod.name().equalsIgnoreCase(value)) {
+				return feeMethod;
+			}
+		}
+		return null;
+	}
+
 	public int getValue() {
 		return i;
 	}

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/FeeMethodConstant.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/FeeMethodConstant.java
@@ -1,0 +1,6 @@
+package com.project.doubleshop.domain.delivery.entity;
+
+public class FeeMethodConstant {
+	public static final int PREPAID_CODE = 7270;
+	public static final int POSTPAID_CODE = 7271;
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/FeeMethodTypeHandler.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/FeeMethodTypeHandler.java
@@ -1,0 +1,32 @@
+package com.project.doubleshop.domain.delivery.entity;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+
+public class FeeMethodTypeHandler extends BaseTypeHandler<FeeMethod> {
+	@Override
+	public void setNonNullParameter(PreparedStatement ps, int i, FeeMethod parameter, JdbcType jdbcType) throws
+		SQLException {
+		ps.setInt(i, parameter.getValue());
+	}
+
+	@Override
+	public FeeMethod getNullableResult(ResultSet rs, String columnName) throws SQLException {
+		return FeeMethod.of(rs.getInt(columnName));
+	}
+
+	@Override
+	public FeeMethod getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+		return FeeMethod.of(rs.getInt(columnIndex));
+	}
+
+	@Override
+	public FeeMethod getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+		return FeeMethod.of(cs.getInt(columnIndex));
+	}
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/FeePolicy.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/FeePolicy.java
@@ -1,0 +1,46 @@
+package com.project.doubleshop.domain.delivery.entity;
+
+import static com.project.doubleshop.domain.delivery.entity.FeePolicyConstant.*;
+
+public enum FeePolicy {
+	FREE(FREE_CODE),
+	ONCE(ONCE_CODE),
+	ON_CONDITION(ON_CONDITION_CODE);
+
+	private final int i;
+
+	FeePolicy(int i) {
+		this.i = i;
+	}
+
+	public static FeePolicy of(int value) {
+		switch (value) {
+			case FREE_CODE:
+				return FeePolicy.FREE;
+			case ONCE_CODE:
+				return FeePolicy.ONCE;
+			case ON_CONDITION_CODE:
+				return FeePolicy.ON_CONDITION;
+			default:
+				throw new AssertionError(String.format("Unknown FeePolicy value : %d", value));
+		}
+	}
+
+	public static FeePolicy of(String value) {
+		for (FeePolicy feePolicy : FeePolicy.values()) {
+			if (feePolicy.name().equalsIgnoreCase(value)) {
+				return feePolicy;
+			}
+		}
+		return null;
+	}
+
+	public int getValue() {
+		return i;
+	}
+
+	@Override
+	public String toString() {
+		return this.name();
+	}
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/FeePolicyConstant.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/FeePolicyConstant.java
@@ -1,0 +1,7 @@
+package com.project.doubleshop.domain.delivery.entity;
+
+public class FeePolicyConstant {
+	public static final int FREE_CODE = 1000;
+	public static final int ONCE_CODE = 1001;
+	public static final int ON_CONDITION_CODE = 1002;
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/entity/FeePolicyTypeHandler.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/entity/FeePolicyTypeHandler.java
@@ -1,0 +1,34 @@
+package com.project.doubleshop.domain.delivery.entity;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+
+
+
+public class FeePolicyTypeHandler extends BaseTypeHandler<FeePolicy> {
+	@Override
+	public void setNonNullParameter(PreparedStatement ps, int i, FeePolicy parameter, JdbcType jdbcType) throws
+		SQLException {
+		ps.setInt(i, parameter.getValue());
+	}
+
+	@Override
+	public FeePolicy getNullableResult(ResultSet rs, String columnName) throws SQLException {
+		return FeePolicy.of(rs.getInt(columnName));
+	}
+
+	@Override
+	public FeePolicy getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+		return FeePolicy.of(rs.getInt(columnIndex));
+	}
+
+	@Override
+	public FeePolicy getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+		return FeePolicy.of(cs.getInt(columnIndex));
+	}
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/mapper/DeliveryDriverMapper.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/mapper/DeliveryDriverMapper.java
@@ -6,6 +6,7 @@ import org.apache.ibatis.annotations.Mapper;
 
 import com.project.doubleshop.domain.common.Status;
 import com.project.doubleshop.domain.delivery.entity.DeliveryDriver;
+import com.project.doubleshop.web.common.StatusRequest;
 import com.project.doubleshop.web.config.support.Pageable;
 
 @Mapper
@@ -15,4 +16,5 @@ public interface DeliveryDriverMapper {
 	List<DeliveryDriver> selectAllDeliveryDriver(Pageable pageable);
 	int updateDeliveryDriver(DeliveryDriver deliveryDriver);
 	int deleteDeliveryDriver(Status status);
+	int updateDeliveryDriverStatus(StatusRequest statusRequest);
 }

--- a/src/main/java/com/project/doubleshop/domain/delivery/mapper/DeliveryDriverMapper.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/mapper/DeliveryDriverMapper.java
@@ -1,0 +1,18 @@
+package com.project.doubleshop.domain.delivery.mapper;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.project.doubleshop.domain.common.Status;
+import com.project.doubleshop.domain.delivery.entity.DeliveryDriver;
+import com.project.doubleshop.web.config.support.Pageable;
+
+@Mapper
+public interface DeliveryDriverMapper {
+	int insertDeliveryDriver(DeliveryDriver deliveryDriver);
+	DeliveryDriver selectByDeliveryDriverId(Long id);
+	List<DeliveryDriver> selectAllDeliveryDriver(Pageable pageable);
+	int updateDeliveryDriver(DeliveryDriver deliveryDriver);
+	int deleteDeliveryDriver(Status status);
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/mapper/DeliveryMapper.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/mapper/DeliveryMapper.java
@@ -1,0 +1,12 @@
+package com.project.doubleshop.domain.delivery.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.project.doubleshop.domain.delivery.entity.Delivery;
+
+@Mapper
+public interface DeliveryMapper {
+	int insertDelivery(Delivery delivery);
+	Delivery selectByDeliveryId(Long id);
+	int updateDelivery(Delivery delivery);
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/mapper/DeliveryMapper.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/mapper/DeliveryMapper.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import com.project.doubleshop.domain.common.Status;
 import com.project.doubleshop.domain.delivery.entity.Delivery;
 import com.project.doubleshop.web.config.support.Pageable;
 
@@ -13,4 +14,5 @@ public interface DeliveryMapper {
 	Delivery selectByDeliveryId(Long id);
 	List<Delivery> selectAllDelivery(Pageable pageable);
 	int updateDelivery(Delivery delivery);
+	int deleteDelivery(Status status);
 }

--- a/src/main/java/com/project/doubleshop/domain/delivery/mapper/DeliveryMapper.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/mapper/DeliveryMapper.java
@@ -6,6 +6,7 @@ import org.apache.ibatis.annotations.Mapper;
 
 import com.project.doubleshop.domain.common.Status;
 import com.project.doubleshop.domain.delivery.entity.Delivery;
+import com.project.doubleshop.web.common.StatusRequest;
 import com.project.doubleshop.web.config.support.Pageable;
 
 @Mapper
@@ -15,4 +16,5 @@ public interface DeliveryMapper {
 	List<Delivery> selectAllDelivery(Pageable pageable);
 	int updateDelivery(Delivery delivery);
 	int deleteDelivery(Status status);
+	int updateDeliveryStatus(StatusRequest statusRequest);
 }

--- a/src/main/java/com/project/doubleshop/domain/delivery/mapper/DeliveryMapper.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/mapper/DeliveryMapper.java
@@ -1,12 +1,16 @@
 package com.project.doubleshop.domain.delivery.mapper;
 
+import java.util.List;
+
 import org.apache.ibatis.annotations.Mapper;
 
 import com.project.doubleshop.domain.delivery.entity.Delivery;
+import com.project.doubleshop.web.config.support.Pageable;
 
 @Mapper
 public interface DeliveryMapper {
 	int insertDelivery(Delivery delivery);
 	Delivery selectByDeliveryId(Long id);
+	List<Delivery> selectAllDelivery(Pageable pageable);
 	int updateDelivery(Delivery delivery);
 }

--- a/src/main/java/com/project/doubleshop/domain/delivery/mapper/DeliveryPolicyMapper.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/mapper/DeliveryPolicyMapper.java
@@ -6,6 +6,7 @@ import org.apache.ibatis.annotations.Mapper;
 
 import com.project.doubleshop.domain.common.Status;
 import com.project.doubleshop.domain.delivery.entity.DeliveryPolicy;
+import com.project.doubleshop.web.common.StatusRequest;
 import com.project.doubleshop.web.config.support.Pageable;
 
 @Mapper
@@ -15,4 +16,5 @@ public interface DeliveryPolicyMapper {
 	List<DeliveryPolicy> selectAllDeliveryPolicy(Pageable pageable);
 	int updateDeliveryPolicy(DeliveryPolicy deliveryPolicy);
 	int deleteDeliveryPolicy(Status status);
+	int updateDeliveryPolicyStatus(StatusRequest statusRequest);
 }

--- a/src/main/java/com/project/doubleshop/domain/delivery/mapper/DeliveryPolicyMapper.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/mapper/DeliveryPolicyMapper.java
@@ -1,7 +1,18 @@
 package com.project.doubleshop.domain.delivery.mapper;
 
+import java.util.List;
+
 import org.apache.ibatis.annotations.Mapper;
+
+import com.project.doubleshop.domain.common.Status;
+import com.project.doubleshop.domain.delivery.entity.DeliveryPolicy;
+import com.project.doubleshop.web.config.support.Pageable;
 
 @Mapper
 public interface DeliveryPolicyMapper {
+	int insertDeliveryPolicy(DeliveryPolicy deliveryPolicy);
+	DeliveryPolicy selectByDeliveryPolicy(Long id);
+	List<DeliveryPolicy> selectAllDeliveryPolicy(Pageable pageable);
+	int updateDeliveryPolicy(DeliveryPolicy deliveryPolicy);
+	int deleteDeliveryDriver(Status status);
 }

--- a/src/main/java/com/project/doubleshop/domain/delivery/mapper/DeliveryPolicyMapper.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/mapper/DeliveryPolicyMapper.java
@@ -1,0 +1,7 @@
+package com.project.doubleshop.domain.delivery.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface DeliveryPolicyMapper {
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/mapper/DeliveryPolicyMapper.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/mapper/DeliveryPolicyMapper.java
@@ -14,5 +14,5 @@ public interface DeliveryPolicyMapper {
 	DeliveryPolicy selectByDeliveryPolicy(Long id);
 	List<DeliveryPolicy> selectAllDeliveryPolicy(Pageable pageable);
 	int updateDeliveryPolicy(DeliveryPolicy deliveryPolicy);
-	int deleteDeliveryDriver(Status status);
+	int deleteDeliveryPolicy(Status status);
 }

--- a/src/main/java/com/project/doubleshop/domain/delivery/repository/DeliveryDriverRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/repository/DeliveryDriverRepository.java
@@ -4,11 +4,13 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
+import com.project.doubleshop.domain.common.Manageable;
 import com.project.doubleshop.domain.delivery.entity.DeliveryDriver;
+import com.project.doubleshop.web.common.StatusRequest;
 import com.project.doubleshop.web.config.support.Pageable;
 
 @Repository
-public interface DeliveryDriverRepository {
+public interface DeliveryDriverRepository extends Manageable<StatusRequest> {
 
 	boolean save(DeliveryDriver deliveryDriver);
 

--- a/src/main/java/com/project/doubleshop/domain/delivery/repository/DeliveryDriverRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/repository/DeliveryDriverRepository.java
@@ -1,0 +1,18 @@
+package com.project.doubleshop.domain.delivery.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.project.doubleshop.domain.delivery.entity.DeliveryDriver;
+import com.project.doubleshop.web.config.support.Pageable;
+
+@Repository
+public interface DeliveryDriverRepository {
+
+	boolean save(DeliveryDriver deliveryDriver);
+
+	DeliveryDriver findById(Long id);
+
+	List<DeliveryDriver> findAll(Pageable pageable);
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/repository/DeliveryPolicyRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/repository/DeliveryPolicyRepository.java
@@ -4,11 +4,13 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
+import com.project.doubleshop.domain.common.Manageable;
 import com.project.doubleshop.domain.delivery.entity.DeliveryPolicy;
+import com.project.doubleshop.web.common.StatusRequest;
 import com.project.doubleshop.web.config.support.Pageable;
 
 @Repository
-public interface DeliveryPolicyRepository {
+public interface DeliveryPolicyRepository extends Manageable<StatusRequest> {
 
 	boolean save(DeliveryPolicy deliveryPolicy);
 

--- a/src/main/java/com/project/doubleshop/domain/delivery/repository/DeliveryPolicyRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/repository/DeliveryPolicyRepository.java
@@ -1,0 +1,18 @@
+package com.project.doubleshop.domain.delivery.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.project.doubleshop.domain.delivery.entity.DeliveryPolicy;
+import com.project.doubleshop.web.config.support.Pageable;
+
+@Repository
+public interface DeliveryPolicyRepository {
+
+	boolean save(DeliveryPolicy deliveryPolicy);
+
+	DeliveryPolicy findById(Long id);
+
+	List<DeliveryPolicy> findAll(Pageable pageable);
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/repository/DeliveryRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/repository/DeliveryRepository.java
@@ -1,0 +1,15 @@
+package com.project.doubleshop.domain.delivery.repository;
+
+import java.util.List;
+
+import com.project.doubleshop.domain.delivery.entity.Delivery;
+import com.project.doubleshop.web.config.support.Pageable;
+
+public interface DeliveryRepository {
+
+	boolean save(Delivery delivery);
+
+	Delivery findById(Long id);
+
+	List<Delivery> findAll(Pageable pageable);
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/repository/DeliveryRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/repository/DeliveryRepository.java
@@ -2,10 +2,12 @@ package com.project.doubleshop.domain.delivery.repository;
 
 import java.util.List;
 
+import com.project.doubleshop.domain.common.Manageable;
 import com.project.doubleshop.domain.delivery.entity.Delivery;
+import com.project.doubleshop.web.common.StatusRequest;
 import com.project.doubleshop.web.config.support.Pageable;
 
-public interface DeliveryRepository {
+public interface DeliveryRepository extends Manageable<StatusRequest> {
 
 	boolean save(Delivery delivery);
 

--- a/src/main/java/com/project/doubleshop/domain/delivery/repository/MyBatisDeliveryDriverRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/repository/MyBatisDeliveryDriverRepository.java
@@ -1,0 +1,39 @@
+package com.project.doubleshop.domain.delivery.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.project.doubleshop.domain.delivery.entity.DeliveryDriver;
+import com.project.doubleshop.domain.delivery.mapper.DeliveryDriverMapper;
+import com.project.doubleshop.web.config.support.Pageable;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MyBatisDeliveryDriverRepository implements DeliveryDriverRepository {
+
+	private final DeliveryDriverMapper mapper;
+
+	@Override
+	public boolean save(DeliveryDriver deliveryDriver) {
+		int affectedRowCnt;
+		if (deliveryDriver.getId() != null) {
+			affectedRowCnt = mapper.updateDeliveryDriver(deliveryDriver);
+		} else {
+			affectedRowCnt = mapper.insertDeliveryDriver(deliveryDriver);
+		}
+		return affectedRowCnt != 0;
+	}
+
+	@Override
+	public DeliveryDriver findById(Long id) {
+		return mapper.selectByDeliveryDriverId(id);
+	}
+
+	@Override
+	public List<DeliveryDriver> findAll(Pageable pageable) {
+		return mapper.selectAllDeliveryDriver(pageable);
+	}
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/repository/MyBatisDeliveryDriverRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/repository/MyBatisDeliveryDriverRepository.java
@@ -4,8 +4,10 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
+import com.project.doubleshop.domain.common.Status;
 import com.project.doubleshop.domain.delivery.entity.DeliveryDriver;
 import com.project.doubleshop.domain.delivery.mapper.DeliveryDriverMapper;
+import com.project.doubleshop.web.common.StatusRequest;
 import com.project.doubleshop.web.config.support.Pageable;
 
 import lombok.RequiredArgsConstructor;
@@ -35,5 +37,15 @@ public class MyBatisDeliveryDriverRepository implements DeliveryDriverRepository
 	@Override
 	public List<DeliveryDriver> findAll(Pageable pageable) {
 		return mapper.selectAllDeliveryDriver(pageable);
+	}
+
+	@Override
+	public int updateStatus(StatusRequest requestDTO) {
+		return mapper.updateDeliveryDriverStatus(requestDTO);
+	}
+
+	@Override
+	public int deleteData(Status status) {
+		return mapper.deleteDeliveryDriver(status);
 	}
 }

--- a/src/main/java/com/project/doubleshop/domain/delivery/repository/MyBatisDeliveryPolicyRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/repository/MyBatisDeliveryPolicyRepository.java
@@ -1,0 +1,39 @@
+package com.project.doubleshop.domain.delivery.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.project.doubleshop.domain.delivery.entity.DeliveryPolicy;
+import com.project.doubleshop.domain.delivery.mapper.DeliveryPolicyMapper;
+import com.project.doubleshop.web.config.support.Pageable;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MyBatisDeliveryPolicyRepository implements DeliveryPolicyRepository {
+
+	private final DeliveryPolicyMapper mapper;
+
+	@Override
+	public boolean save(DeliveryPolicy deliveryPolicy) {
+		int affectedRowCnt;
+		if (deliveryPolicy.getId() != null) {
+			affectedRowCnt = mapper.updateDeliveryPolicy(deliveryPolicy);
+		} else {
+			affectedRowCnt = mapper.insertDeliveryPolicy(deliveryPolicy);
+		}
+		return affectedRowCnt != 0;
+	}
+
+	@Override
+	public DeliveryPolicy findById(Long id) {
+		return mapper.selectByDeliveryPolicy(id);
+	}
+
+	@Override
+	public List<DeliveryPolicy> findAll(Pageable pageable) {
+		return mapper.selectAllDeliveryPolicy(pageable);
+	}
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/repository/MyBatisDeliveryPolicyRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/repository/MyBatisDeliveryPolicyRepository.java
@@ -4,8 +4,10 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
+import com.project.doubleshop.domain.common.Status;
 import com.project.doubleshop.domain.delivery.entity.DeliveryPolicy;
 import com.project.doubleshop.domain.delivery.mapper.DeliveryPolicyMapper;
+import com.project.doubleshop.web.common.StatusRequest;
 import com.project.doubleshop.web.config.support.Pageable;
 
 import lombok.RequiredArgsConstructor;
@@ -35,5 +37,15 @@ public class MyBatisDeliveryPolicyRepository implements DeliveryPolicyRepository
 	@Override
 	public List<DeliveryPolicy> findAll(Pageable pageable) {
 		return mapper.selectAllDeliveryPolicy(pageable);
+	}
+
+	@Override
+	public int updateStatus(StatusRequest requestDTO) {
+		return mapper.updateDeliveryPolicyStatus(requestDTO);
+	}
+
+	@Override
+	public int deleteData(Status status) {
+		return mapper.deleteDeliveryPolicy(status);
 	}
 }

--- a/src/main/java/com/project/doubleshop/domain/delivery/repository/MyBatisDeliveryRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/repository/MyBatisDeliveryRepository.java
@@ -1,0 +1,39 @@
+package com.project.doubleshop.domain.delivery.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.project.doubleshop.domain.delivery.entity.Delivery;
+import com.project.doubleshop.domain.delivery.mapper.DeliveryMapper;
+import com.project.doubleshop.web.config.support.Pageable;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MyBatisDeliveryRepository implements DeliveryRepository {
+
+	private final DeliveryMapper mapper;
+
+	@Override
+	public boolean save(Delivery delivery) {
+		int affectedRowCnt;
+		if (delivery.getId() != null) {
+			affectedRowCnt = mapper.updateDelivery(delivery);
+		} else {
+			affectedRowCnt = mapper.insertDelivery(delivery);
+		}
+		return affectedRowCnt != 0;
+	}
+
+	@Override
+	public Delivery findById(Long id) {
+		return mapper.selectByDeliveryId(id);
+	}
+
+	@Override
+	public List<Delivery> findAll(Pageable pageable) {
+		return mapper.selectAllDelivery(pageable);
+	}
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/repository/MyBatisDeliveryRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/repository/MyBatisDeliveryRepository.java
@@ -4,8 +4,10 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
+import com.project.doubleshop.domain.common.Status;
 import com.project.doubleshop.domain.delivery.entity.Delivery;
 import com.project.doubleshop.domain.delivery.mapper.DeliveryMapper;
+import com.project.doubleshop.web.common.StatusRequest;
 import com.project.doubleshop.web.config.support.Pageable;
 
 import lombok.RequiredArgsConstructor;
@@ -35,5 +37,15 @@ public class MyBatisDeliveryRepository implements DeliveryRepository {
 	@Override
 	public List<Delivery> findAll(Pageable pageable) {
 		return mapper.selectAllDelivery(pageable);
+	}
+
+	@Override
+	public int updateStatus(StatusRequest requestDTO) {
+		return mapper.updateDeliveryStatus(requestDTO);
+	}
+
+	@Override
+	public int deleteData(Status status) {
+		return mapper.deleteDelivery(status);
 	}
 }

--- a/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryDriverService.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryDriverService.java
@@ -6,8 +6,10 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.project.doubleshop.domain.common.Status;
 import com.project.doubleshop.domain.delivery.entity.DeliveryDriver;
 import com.project.doubleshop.domain.delivery.repository.DeliveryDriverRepository;
+import com.project.doubleshop.web.common.StatusRequest;
 import com.project.doubleshop.web.config.support.Pageable;
 import com.project.doubleshop.web.item.exception.DataNotFoundException;
 
@@ -44,5 +46,37 @@ public class DeliveryDriverService {
 	public DeliveryDriver findById(Long deliveryDriverId) {
 		return findByDeliverDriverId(deliveryDriverId).orElseThrow(() ->
 			new DataNotFoundException(String.format("DeliveryDriver ID '%s' not found.", deliveryDriverId)));
+	}
+
+	@Transactional
+	public DeliveryDriver getInsertedDeliveryDriver(DeliveryDriver deliveryDriver) {
+		if (saveDeliveryDriver(deliveryDriver)) {
+			return deliveryDriver;
+		} else {
+			throw new DataNotFoundException(String.format("Inserted deliveryPolicy id %d not found", deliveryDriver.getId()));
+		}
+	}
+
+	@Transactional
+	public void updateDeliveryDriverStatus(StatusRequest requestDTO) {
+		DeliveryDriver deliveryDriver = deliveryDriverRepository.findById(requestDTO.getId());
+		if (deliveryDriver == null) {
+			throw new DataNotFoundException(String.format("DeliveryDriver Id '%s' not found.", requestDTO.getId()));
+		}
+		if (Status.of(requestDTO.getStatus().name()) == null) {
+			throw new IllegalArgumentException(String.format("Request status value '%s' not found", requestDTO.getStatus().name()));
+		}
+		deliveryDriverRepository.updateStatus(requestDTO);
+	}
+
+	@Transactional
+	public DeliveryDriver updateDeliveryDriverStatus(Status status, Long deliveryDriverId) {
+		updateDeliveryDriverStatus(new StatusRequest(deliveryDriverId, status));
+		return findById(deliveryDriverId);
+	}
+
+	@Transactional
+	public Integer deleteDeliveryDrivers(Status status) {
+		return deliveryDriverRepository.deleteData(status);
 	}
 }

--- a/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryDriverService.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryDriverService.java
@@ -40,4 +40,9 @@ public class DeliveryDriverService {
 	public List<DeliveryDriver> findDeliverDrivers(Pageable pageable) {
 		return deliveryDriverRepository.findAll(pageable);
 	}
+
+	public DeliveryDriver findById(Long deliveryDriverId) {
+		return findByDeliverDriverId(deliveryDriverId).orElseThrow(() ->
+			new DataNotFoundException(String.format("DeliveryDriver ID '%s' not found.", deliveryDriverId)));
+	}
 }

--- a/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryDriverService.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryDriverService.java
@@ -1,0 +1,43 @@
+package com.project.doubleshop.domain.delivery.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.project.doubleshop.domain.delivery.entity.DeliveryDriver;
+import com.project.doubleshop.domain.delivery.repository.DeliveryDriverRepository;
+import com.project.doubleshop.web.config.support.Pageable;
+import com.project.doubleshop.web.item.exception.DataNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DeliveryDriverService {
+
+	private final DeliveryDriverRepository deliveryDriverRepository;
+
+	@Transactional
+	public boolean saveDeliveryDriver(DeliveryDriver deliveryDriver) {
+		return deliveryDriverRepository.save(deliveryDriver);
+	}
+
+	@Transactional
+	public DeliveryDriver saveDeliveryDriver(DeliveryDriver deliveryDriver, Long deliveryDriverId) {
+		findByDeliverDriverId(deliveryDriverId).orElseThrow(() ->
+			new DataNotFoundException(String.format("DeliveryDriver ID '%s' not found.", deliveryDriverId)));
+		deliveryDriverRepository.save(deliveryDriver);
+		return deliveryDriverRepository.findById(deliveryDriverId);
+	}
+
+	public Optional<DeliveryDriver> findByDeliverDriverId(Long deliveryDriverId) {
+		return Optional.ofNullable(deliveryDriverRepository.findById(deliveryDriverId));
+	}
+
+	public List<DeliveryDriver> findDeliverDrivers(Pageable pageable) {
+		return deliveryDriverRepository.findAll(pageable);
+	}
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryManagementService.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryManagementService.java
@@ -1,0 +1,12 @@
+package com.project.doubleshop.domain.delivery.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DeliveryManagementService {
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryManagementService.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryManagementService.java
@@ -9,4 +9,6 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class DeliveryManagementService {
+	private final DeliveryService deliveryService;
+	
 }

--- a/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryPolicyService.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryPolicyService.java
@@ -40,4 +40,9 @@ public class DeliveryPolicyService {
 	public List<DeliveryPolicy> findDeliveryPolicies(Pageable pageable) {
 		return deliveryPolicyRepository.findAll(pageable);
 	}
+
+	public DeliveryPolicy findById(Long deliveryPolicyId) {
+		return findByDeliveryPolicyId(deliveryPolicyId).orElseThrow(() ->
+			new DataNotFoundException(String.format("Delivery ID '%s' not found.", deliveryPolicyId)));
+	}
 }

--- a/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryPolicyService.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryPolicyService.java
@@ -6,8 +6,10 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.project.doubleshop.domain.common.Status;
 import com.project.doubleshop.domain.delivery.entity.DeliveryPolicy;
 import com.project.doubleshop.domain.delivery.repository.DeliveryPolicyRepository;
+import com.project.doubleshop.web.common.StatusRequest;
 import com.project.doubleshop.web.config.support.Pageable;
 import com.project.doubleshop.web.item.exception.DataNotFoundException;
 
@@ -44,5 +46,36 @@ public class DeliveryPolicyService {
 	public DeliveryPolicy findById(Long deliveryPolicyId) {
 		return findByDeliveryPolicyId(deliveryPolicyId).orElseThrow(() ->
 			new DataNotFoundException(String.format("Delivery ID '%s' not found.", deliveryPolicyId)));
+	}
+
+	@Transactional
+	public DeliveryPolicy getInsertedDeliveryPolicy(DeliveryPolicy deliveryPolicy) {
+		if (saveDeliveryPolicy(deliveryPolicy)) {
+			return deliveryPolicy;
+		} else {
+			throw new DataNotFoundException(String.format("Inserted deliveryPolicy id %d not found", deliveryPolicy.getId()));
+		}
+	}
+
+	@Transactional
+	public void updateDeliveryPolicyStatus(StatusRequest requestDTO) {
+		DeliveryPolicy deliveryPolicy = deliveryPolicyRepository.findById(requestDTO.getId());
+		if (deliveryPolicy == null) {
+			throw new DataNotFoundException(String.format("DeliveryPolicy Id '%s' not found.", requestDTO.getId()));
+		}
+		if (Status.of(requestDTO.getStatus().name()) == null) {
+			throw new IllegalArgumentException(String.format("Request status value '%s' not found", requestDTO.getStatus().name()));
+		}
+		deliveryPolicyRepository.updateStatus(requestDTO);
+	}
+
+	@Transactional
+	public DeliveryPolicy updateDeliveryPolicyStatus(Status status, Long deliveryPolicyId) {
+		updateDeliveryPolicyStatus(new StatusRequest(deliveryPolicyId, status));
+		return findById(deliveryPolicyId);
+	}
+
+	public Integer deleteDeliveryPolices(Status status) {
+		return deliveryPolicyRepository.deleteData(status);
 	}
 }

--- a/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryPolicyService.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryPolicyService.java
@@ -75,6 +75,7 @@ public class DeliveryPolicyService {
 		return findById(deliveryPolicyId);
 	}
 
+	@Transactional
 	public Integer deleteDeliveryPolices(Status status) {
 		return deliveryPolicyRepository.deleteData(status);
 	}

--- a/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryPolicyService.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryPolicyService.java
@@ -1,0 +1,43 @@
+package com.project.doubleshop.domain.delivery.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.project.doubleshop.domain.delivery.entity.DeliveryPolicy;
+import com.project.doubleshop.domain.delivery.repository.DeliveryPolicyRepository;
+import com.project.doubleshop.web.config.support.Pageable;
+import com.project.doubleshop.web.item.exception.DataNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DeliveryPolicyService {
+
+	private final DeliveryPolicyRepository deliveryPolicyRepository;
+
+	@Transactional
+	public boolean saveDeliveryPolicy(DeliveryPolicy deliveryPolicy) {
+		return deliveryPolicyRepository.save(deliveryPolicy);
+	}
+
+	@Transactional
+	public DeliveryPolicy saveDeliveryPolicy(DeliveryPolicy deliveryPolicy, Long deliveryPolicyId) {
+		findByDeliveryPolicyId(deliveryPolicyId).orElseThrow(() ->
+			new DataNotFoundException(String.format("DeliveryPolicy ID '%s' not found.", deliveryPolicyId)));
+		deliveryPolicyRepository.save(deliveryPolicy);
+		return deliveryPolicyRepository.findById(deliveryPolicyId);
+	}
+
+	public Optional<DeliveryPolicy> findByDeliveryPolicyId(Long deliveryPolicyId) {
+		return Optional.ofNullable(deliveryPolicyRepository.findById(deliveryPolicyId));
+	}
+
+	public List<DeliveryPolicy> findDeliveryPolicies(Pageable pageable) {
+		return deliveryPolicyRepository.findAll(pageable);
+	}
+}

--- a/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryService.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryService.java
@@ -26,8 +26,9 @@ public class DeliveryService {
 	}
 
 	@Transactional
-	public Delivery saveItem(Delivery delivery, Long deliveryId) {
-		findByDeliveryId(deliveryId).orElseThrow(() -> new DataNotFoundException(String.format("Delivery ID '%s' not found.", delivery)));
+	public Delivery saveDelivery(Delivery delivery, Long deliveryId) {
+		findByDeliveryId(deliveryId).orElseThrow(() ->
+			new DataNotFoundException(String.format("Delivery ID '%s' not found.", delivery)));
 		deliveryRepository.save(delivery);
 		return deliveryRepository.findById(deliveryId);
 	}

--- a/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryService.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryService.java
@@ -28,13 +28,17 @@ public class DeliveryService {
 	@Transactional
 	public Delivery saveDelivery(Delivery delivery, Long deliveryId) {
 		findByDeliveryId(deliveryId).orElseThrow(() ->
-			new DataNotFoundException(String.format("Delivery ID '%s' not found.", delivery)));
+			new DataNotFoundException(String.format("Delivery ID '%s' not found.", deliveryId)));
 		deliveryRepository.save(delivery);
 		return deliveryRepository.findById(deliveryId);
 	}
 
 	public Optional<Delivery> findByDeliveryId(Long deliveryId) {
 		return Optional.ofNullable(deliveryRepository.findById(deliveryId));
+	}
+
+	public Delivery findById(Long deliveryId) {
+		return findByDeliveryId(deliveryId).orElseThrow(() -> new DataNotFoundException(String.format("Delivery ID '%s' not found.", deliveryId)));
 	}
 
 	public List<Delivery> findDeliveries(Pageable pageable) {

--- a/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryService.java
+++ b/src/main/java/com/project/doubleshop/domain/delivery/service/DeliveryService.java
@@ -1,0 +1,42 @@
+package com.project.doubleshop.domain.delivery.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.project.doubleshop.domain.delivery.entity.Delivery;
+import com.project.doubleshop.domain.delivery.repository.DeliveryRepository;
+import com.project.doubleshop.web.config.support.Pageable;
+import com.project.doubleshop.web.item.exception.DataNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DeliveryService {
+
+	private final DeliveryRepository deliveryRepository;
+
+	@Transactional
+	public boolean saveDelivery(Delivery delivery) {
+		return deliveryRepository.save(delivery);
+	}
+
+	@Transactional
+	public Delivery saveItem(Delivery delivery, Long deliveryId) {
+		findByDeliveryId(deliveryId).orElseThrow(() -> new DataNotFoundException(String.format("Delivery ID '%s' not found.", delivery)));
+		deliveryRepository.save(delivery);
+		return deliveryRepository.findById(deliveryId);
+	}
+
+	public Optional<Delivery> findByDeliveryId(Long deliveryId) {
+		return Optional.ofNullable(deliveryRepository.findById(deliveryId));
+	}
+
+	public List<Delivery> findDeliveries(Pageable pageable) {
+		return deliveryRepository.findAll(pageable);
+	}
+}

--- a/src/main/java/com/project/doubleshop/web/delivery/controller/api/DeliveryDriverRestController.java
+++ b/src/main/java/com/project/doubleshop/web/delivery/controller/api/DeliveryDriverRestController.java
@@ -1,0 +1,25 @@
+package com.project.doubleshop.web.delivery.controller.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.project.doubleshop.domain.delivery.service.DeliveryDriverService;
+import com.project.doubleshop.web.delivery.dto.DeliveryDriverDTO;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("api/delivery/driver")
+@RequiredArgsConstructor
+public class DeliveryDriverRestController {
+
+	private final DeliveryDriverService deliveryDriverService;
+
+	@PostMapping
+	public ResponseEntity<DeliveryDriverDTO> newDeliveryDriver(@RequestBody DeliveryDriverForm deliveryDriverForm) {
+
+	}
+}

--- a/src/main/java/com/project/doubleshop/web/delivery/controller/api/DeliveryDriverRestController.java
+++ b/src/main/java/com/project/doubleshop/web/delivery/controller/api/DeliveryDriverRestController.java
@@ -1,13 +1,27 @@
 package com.project.doubleshop.web.delivery.controller.api;
 
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import com.project.doubleshop.domain.common.Status;
+import com.project.doubleshop.domain.delivery.entity.DeliveryDriver;
 import com.project.doubleshop.domain.delivery.service.DeliveryDriverService;
+import com.project.doubleshop.web.config.support.Pageable;
 import com.project.doubleshop.web.delivery.dto.DeliveryDriverDTO;
+import com.project.doubleshop.web.delivery.dto.DeliveryDriverForm;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,6 +34,45 @@ public class DeliveryDriverRestController {
 
 	@PostMapping
 	public ResponseEntity<DeliveryDriverDTO> newDeliveryDriver(@RequestBody DeliveryDriverForm deliveryDriverForm) {
+		DeliveryDriver deliveryDriver =
+			deliveryDriverService.getInsertedDeliveryDriver(DeliveryDriver.convertToDeliveryDriver(deliveryDriverForm));
 
+		URI location = ServletUriComponentsBuilder
+			.fromCurrentRequest()
+			.build()
+			.toUri();
+
+		return ResponseEntity.created(location).body(new DeliveryDriverDTO(deliveryDriver));
+	}
+
+	@GetMapping("{id}")
+	public ResponseEntity<DeliveryDriverDTO> findDeliveryDriverById(@PathVariable Long id) {
+		DeliveryDriver deliveryDriver = deliveryDriverService.findById(id);
+
+		return ResponseEntity.ok(new DeliveryDriverDTO(deliveryDriver));
+	}
+
+	@GetMapping
+	public ResponseEntity<List<DeliveryDriverDTO>> findDeliveryPolicies(Pageable pageable) {
+		List<DeliveryDriver> deliverDrivers = deliveryDriverService.findDeliverDrivers(pageable);
+		return ResponseEntity.ok(deliverDrivers.stream().map(DeliveryDriverDTO::new).collect(Collectors.toList()));
+	}
+
+	@PutMapping("{id}")
+	public ResponseEntity<DeliveryDriverDTO> editDeliveryDriver(@RequestBody DeliveryDriverForm deliveryDriverForm,
+		@PathVariable Long id) {
+		DeliveryDriver deliveryDriver = deliveryDriverService.saveDeliveryDriver(
+			DeliveryDriver.convertToDeliveryDriver(deliveryDriverForm), id);
+		return ResponseEntity.ok(new DeliveryDriverDTO(deliveryDriver));
+	}
+
+	@PatchMapping("{id}/status")
+	public ResponseEntity<DeliveryDriverDTO> requestUpdateDeliveryDriverStatus(@RequestBody Status status, @PathVariable Long id) {
+		return ResponseEntity.ok(new DeliveryDriverDTO(deliveryDriverService.updateDeliveryDriverStatus(status, id)));
+	}
+
+	@DeleteMapping
+	public ResponseEntity<Integer> deleteAssignedDeliveryDrivers(@RequestBody Status status) {
+		return ResponseEntity.ok(deliveryDriverService.deleteDeliveryDrivers(status));
 	}
 }

--- a/src/main/java/com/project/doubleshop/web/delivery/controller/api/DeliveryPolicyRestController.java
+++ b/src/main/java/com/project/doubleshop/web/delivery/controller/api/DeliveryPolicyRestController.java
@@ -73,7 +73,7 @@ public class DeliveryPolicyRestController {
 	}
 
 	@DeleteMapping
-	public ResponseEntity<Integer> deleteAssignedDeliveries(@RequestBody Status status) {
+	public ResponseEntity<Integer> deleteAssignedDeliveryPolicies(@RequestBody Status status) {
 		return ResponseEntity.ok(deliveryPolicyService.deleteDeliveryPolices(status));
 	}
 }

--- a/src/main/java/com/project/doubleshop/web/delivery/controller/api/DeliveryPolicyRestController.java
+++ b/src/main/java/com/project/doubleshop/web/delivery/controller/api/DeliveryPolicyRestController.java
@@ -1,0 +1,79 @@
+package com.project.doubleshop.web.delivery.controller.api;
+
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import com.project.doubleshop.domain.common.Status;
+import com.project.doubleshop.domain.delivery.entity.DeliveryPolicy;
+import com.project.doubleshop.domain.delivery.service.DeliveryPolicyService;
+import com.project.doubleshop.web.config.support.Pageable;
+import com.project.doubleshop.web.delivery.dto.DeliveryDTO;
+import com.project.doubleshop.web.delivery.dto.DeliveryPolicyDTO;
+import com.project.doubleshop.web.delivery.dto.DeliveryPolicyForm;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("api/delivery/policy")
+@RequiredArgsConstructor
+public class DeliveryPolicyRestController {
+
+	private final DeliveryPolicyService deliveryPolicyService;
+
+	@PostMapping
+	public ResponseEntity<DeliveryPolicyDTO> newDeliveryPolicy(@RequestBody DeliveryPolicyForm deliveryPolicyForm) {
+		DeliveryPolicy deliveryPolicy =
+			deliveryPolicyService.getInsertedDeliveryPolicy(DeliveryPolicy.convertToDeliveryPolicy(deliveryPolicyForm));
+
+		URI location = ServletUriComponentsBuilder
+			.fromCurrentRequest()
+			.build()
+			.toUri();
+
+		return ResponseEntity.created(location).body(new DeliveryPolicyDTO(deliveryPolicy));
+	}
+
+	@GetMapping("{id}")
+	public ResponseEntity<DeliveryPolicyDTO> findDeliveryPolicyById(@PathVariable Long id) {
+		DeliveryPolicy deliveryPolicy = deliveryPolicyService.findById(id);
+
+		return ResponseEntity.ok(new DeliveryPolicyDTO(deliveryPolicy));
+	}
+
+	@GetMapping
+	public ResponseEntity<List<DeliveryPolicyDTO>> findDeliveryPolicies(Pageable pageable) {
+		List<DeliveryPolicy> deliveryPolicies = deliveryPolicyService.findDeliveryPolicies(pageable);
+		return ResponseEntity.ok(deliveryPolicies.stream().map(DeliveryPolicyDTO::new).collect(Collectors.toList()));
+	}
+
+	@PutMapping("{id}")
+	public ResponseEntity<DeliveryPolicyDTO> editDeliveryPolicy(@RequestBody DeliveryPolicyForm deliveryPolicyForm,
+		@PathVariable Long id) {
+		DeliveryPolicy deliveryPolicy = deliveryPolicyService.saveDeliveryPolicy(
+			DeliveryPolicy.convertToDeliveryPolicy(deliveryPolicyForm), id);
+		return ResponseEntity.ok(new DeliveryPolicyDTO(deliveryPolicy));
+	}
+
+	@PatchMapping("{id}/status")
+	public ResponseEntity<DeliveryPolicyDTO> requestUpdateDeliveryPolicyStatus(@RequestBody Status status, @PathVariable Long id) {
+		return ResponseEntity.ok(new DeliveryPolicyDTO(deliveryPolicyService.updateDeliveryPolicyStatus(status, id)));
+	}
+
+	@DeleteMapping
+	public ResponseEntity<Integer> deleteAssignedDeliveries(@RequestBody Status status) {
+		return ResponseEntity.ok(deliveryPolicyService.deleteDeliveryPolices(status));
+	}
+}

--- a/src/main/java/com/project/doubleshop/web/delivery/controller/api/DeliveryRestController.java
+++ b/src/main/java/com/project/doubleshop/web/delivery/controller/api/DeliveryRestController.java
@@ -2,6 +2,7 @@ package com.project.doubleshop.web.delivery.controller.api;
 
 import java.net.URI;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -31,7 +32,7 @@ import com.project.doubleshop.web.delivery.dto.DeliveryForm;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("api")
+@RequestMapping("api/delivery")
 @RequiredArgsConstructor
 public class DeliveryRestController {
 
@@ -41,7 +42,7 @@ public class DeliveryRestController {
 
 	private final DeliveryPolicyService deliveryPolicyService;
 
-	@PostMapping("delivery")
+	@PostMapping
 	public ResponseEntity<DeliveryDTO> newDelivery(@RequestBody DeliveryForm deliveryForm) {
 		Delivery delivery = deliveryService.getInsertedDelivery(Delivery.convertToDelivery(deliveryForm));
 
@@ -53,7 +54,7 @@ public class DeliveryRestController {
 		return ResponseEntity.created(location).body(new DeliveryDTO(delivery));
 	}
 
-	@GetMapping("delivery/{id}")
+	@GetMapping("{id}")
 	public ResponseEntity<DeliveryApiResult> findDeliveryById(@PathVariable Long id) {
 		Delivery delivery = deliveryService.findById(id);
 
@@ -66,18 +67,25 @@ public class DeliveryRestController {
 		return ResponseEntity.ok(new DeliveryApiResult(delivery, deliveryPolicy, deliveryDriver));
 	}
 
-	@PutMapping("delivery/{id}")
+	@GetMapping
+	public ResponseEntity<List<DeliveryDTO>> findDeliveries(Pageable pageable) {
+		List<Delivery> deliveries = deliveryService.findDeliveries(pageable);
+		return ResponseEntity.ok(deliveries.stream()
+			.map(DeliveryDTO::new).collect(Collectors.toList()));
+	}
+
+	@PutMapping("{id}")
 	public ResponseEntity<DeliveryDTO> editDelivery(@RequestBody DeliveryForm deliveryForm, @PathVariable Long id) {
 		Delivery delivery = deliveryService.saveDelivery(Delivery.convertToDelivery(deliveryForm), id);
 		return ResponseEntity.ok(new DeliveryDTO(delivery));
 	}
 
-	@PatchMapping("delivery/{id}/status")
+	@PatchMapping("{id}/status")
 	public ResponseEntity<DeliveryDTO>  requestUpdateDeliveryStatus(@RequestBody Status status, @PathVariable Long id) {
 		return ResponseEntity.ok(new DeliveryDTO(deliveryService.updateDeliveryStatus(status, id)));
 	}
 
-	@DeleteMapping("delivery")
+	@DeleteMapping
 	public ResponseEntity<Integer> deleteAssignedDeliveries(@RequestParam Status status) {
 		return ResponseEntity.ok(deliveryService.deleteDeliveries(status));
 	}

--- a/src/main/java/com/project/doubleshop/web/delivery/controller/api/DeliveryRestController.java
+++ b/src/main/java/com/project/doubleshop/web/delivery/controller/api/DeliveryRestController.java
@@ -1,0 +1,84 @@
+package com.project.doubleshop.web.delivery.controller.api;
+
+import java.net.URI;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import com.project.doubleshop.domain.common.Status;
+import com.project.doubleshop.domain.delivery.entity.Delivery;
+import com.project.doubleshop.domain.delivery.entity.DeliveryDriver;
+import com.project.doubleshop.domain.delivery.entity.DeliveryPolicy;
+import com.project.doubleshop.domain.delivery.service.DeliveryDriverService;
+import com.project.doubleshop.domain.delivery.service.DeliveryPolicyService;
+import com.project.doubleshop.domain.delivery.service.DeliveryService;
+import com.project.doubleshop.web.config.support.Pageable;
+import com.project.doubleshop.web.delivery.dto.DeliveryApiResult;
+import com.project.doubleshop.web.delivery.dto.DeliveryDTO;
+import com.project.doubleshop.web.delivery.dto.DeliveryForm;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("api")
+@RequiredArgsConstructor
+public class DeliveryRestController {
+
+	private final DeliveryService deliveryService;
+
+	private final DeliveryDriverService deliveryDriverService;
+
+	private final DeliveryPolicyService deliveryPolicyService;
+
+	@PostMapping("delivery")
+	public ResponseEntity<DeliveryDTO> newDelivery(@RequestBody DeliveryForm deliveryForm) {
+		Delivery delivery = deliveryService.getInsertedDelivery(Delivery.convertToDelivery(deliveryForm));
+
+		URI location = ServletUriComponentsBuilder
+			.fromCurrentRequest()
+			.build()
+			.toUri();
+
+		return ResponseEntity.created(location).body(new DeliveryDTO(delivery));
+	}
+
+	@GetMapping("delivery/{id}")
+	public ResponseEntity<DeliveryApiResult> findDeliveryById(@PathVariable Long id) {
+		Delivery delivery = deliveryService.findById(id);
+
+		Long deliveryDriverId = delivery.getDeliveryDriverId();
+		Long deliveryPolicyId = delivery.getDeliveryPolicyId();
+
+		DeliveryPolicy deliveryPolicy = deliveryPolicyService.findById(deliveryPolicyId);
+		DeliveryDriver deliveryDriver = deliveryDriverService.findById(deliveryDriverId);
+
+		return ResponseEntity.ok(new DeliveryApiResult(delivery, deliveryPolicy, deliveryDriver));
+	}
+
+	@PutMapping("delivery/{id}")
+	public ResponseEntity<DeliveryDTO> editDelivery(@RequestBody DeliveryForm deliveryForm, @PathVariable Long id) {
+		Delivery delivery = deliveryService.saveDelivery(Delivery.convertToDelivery(deliveryForm), id);
+		return ResponseEntity.ok(new DeliveryDTO(delivery));
+	}
+
+	@PatchMapping("delivery/{id}/status")
+	public ResponseEntity<DeliveryDTO>  requestUpdateDeliveryStatus(@RequestBody Status status, @PathVariable Long id) {
+		return ResponseEntity.ok(new DeliveryDTO(deliveryService.updateDeliveryStatus(status, id)));
+	}
+
+	@DeleteMapping("delivery")
+	public ResponseEntity<Integer> deleteAssignedDeliveries(@RequestParam Status status) {
+		return ResponseEntity.ok(deliveryService.deleteDeliveries(status));
+	}
+}

--- a/src/main/java/com/project/doubleshop/web/delivery/dto/DeliveryApiResult.java
+++ b/src/main/java/com/project/doubleshop/web/delivery/dto/DeliveryApiResult.java
@@ -1,0 +1,40 @@
+package com.project.doubleshop.web.delivery.dto;
+
+import com.project.doubleshop.domain.delivery.entity.Delivery;
+import com.project.doubleshop.domain.delivery.entity.DeliveryDriver;
+import com.project.doubleshop.domain.delivery.entity.DeliveryPolicy;
+import com.project.doubleshop.domain.delivery.entity.DeliveryStatus;
+import com.project.doubleshop.web.delivery.dto.DeliveryDriverDTO;
+import com.project.doubleshop.web.delivery.dto.DeliveryPolicyDTO;
+
+import lombok.Getter;
+
+@Getter
+public class DeliveryApiResult {
+	// 배송 pk
+	private final Long id;
+
+	// 운송장 번호
+	private final String waybillNumber;
+
+	// 배송 메모
+	private final String memo;
+
+	// 배송 상태
+	private final DeliveryStatus deliveryStatus;
+
+	// 배송정책 fk
+	private final DeliveryPolicyDTO deliveryPolicy;
+
+	// 배송기사 fk
+	private final DeliveryDriverDTO deliveryDriver;
+
+	public DeliveryApiResult(Delivery delivery, DeliveryPolicy deliveryPolicy, DeliveryDriver deliveryDriver) {
+		this.id = delivery.getId();
+		this.waybillNumber = delivery.getWaybillNumber();
+		this.memo = delivery.getMemo();
+		this.deliveryStatus = delivery.getDeliveryStatus();
+		this.deliveryPolicy = new DeliveryPolicyDTO(deliveryPolicy);
+		this.deliveryDriver = new DeliveryDriverDTO(deliveryDriver);
+	}
+}

--- a/src/main/java/com/project/doubleshop/web/delivery/dto/DeliveryDTO.java
+++ b/src/main/java/com/project/doubleshop/web/delivery/dto/DeliveryDTO.java
@@ -1,0 +1,37 @@
+package com.project.doubleshop.web.delivery.dto;
+
+import com.project.doubleshop.domain.delivery.entity.Delivery;
+import com.project.doubleshop.domain.delivery.entity.DeliveryStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class DeliveryDTO {
+	// 배송 pk
+	private final Long id;
+
+	// 운송장 번호
+	private final String waybillNumber;
+
+	// 배송 메모
+	private final String memo;
+
+	// 배송 상태
+	private final DeliveryStatus deliveryStatus;
+
+	// 배송정책 fk
+	private final Long deliveryPolicyId;
+
+	// 배송기사 fk
+	private final Long deliveryDriverId;
+
+	public DeliveryDTO(Delivery source) {
+		this.id = source.getId();
+		this.waybillNumber = source.getWaybillNumber();
+		this.memo = source.getMemo();
+		this.deliveryStatus = source.getDeliveryStatus();
+		this.deliveryPolicyId = source.getDeliveryPolicyId();
+		this.deliveryDriverId = source.getDeliveryDriverId();
+	}
+}

--- a/src/main/java/com/project/doubleshop/web/delivery/dto/DeliveryDriverDTO.java
+++ b/src/main/java/com/project/doubleshop/web/delivery/dto/DeliveryDriverDTO.java
@@ -1,0 +1,33 @@
+package com.project.doubleshop.web.delivery.dto;
+
+import java.time.LocalDateTime;
+
+import com.project.doubleshop.domain.delivery.entity.DeliveryDriver;
+
+import lombok.Getter;
+
+@Getter
+public class DeliveryDriverDTO {
+	// 배송기사 pk
+	private final Long id;
+
+	// 이름
+	private final String name;
+
+	// 핸드폰 번호
+	private final String phone;
+
+	// 등록일
+	private final LocalDateTime createTime;
+
+	// 수정일
+	private final LocalDateTime updateTime;
+
+	public DeliveryDriverDTO(DeliveryDriver source) {
+		this.id = source.getId();
+		this.name = source.getName();
+		this.phone = source.getPhone();
+		this.createTime = source.getCreateTime();
+		this.updateTime = source.getUpdateTime();
+	}
+}

--- a/src/main/java/com/project/doubleshop/web/delivery/dto/DeliveryDriverForm.java
+++ b/src/main/java/com/project/doubleshop/web/delivery/dto/DeliveryDriverForm.java
@@ -1,0 +1,28 @@
+package com.project.doubleshop.web.delivery.dto;
+
+import java.time.LocalDateTime;
+
+import com.project.doubleshop.domain.delivery.entity.DeliveryDriver;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeliveryDriverForm {
+	// 배송기사 pk
+	private Long id;
+
+	// 이름
+	private String name;
+
+	// 핸드폰 번호
+	private String phone;
+
+	public DeliveryDriverForm(DeliveryDriver source) {
+		this.id = source.getId();
+		this.name = source.getName();
+		this.phone = source.getPhone();
+	}
+}

--- a/src/main/java/com/project/doubleshop/web/delivery/dto/DeliveryForm.java
+++ b/src/main/java/com/project/doubleshop/web/delivery/dto/DeliveryForm.java
@@ -1,0 +1,42 @@
+package com.project.doubleshop.web.delivery.dto;
+
+import java.time.LocalDateTime;
+
+import com.project.doubleshop.domain.common.Status;
+import com.project.doubleshop.domain.delivery.entity.Delivery;
+import com.project.doubleshop.domain.delivery.entity.DeliveryStatus;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeliveryForm {
+	// 배송 pk
+	private Long id;
+
+	// 운송장 번호
+	private String waybillNumber;
+
+	// 배송 메모
+	private String memo;
+
+	// 배송 상태
+	private DeliveryStatus deliveryStatus;
+
+	// 배송정책 fk
+	private Long deliveryPolicyId;
+
+	// 배송기사 fk
+	private Long deliveryDriverId;
+
+	public DeliveryForm(Delivery source) {
+		this.id = source.getId();
+		this.waybillNumber = source.getWaybillNumber();
+		this.memo = source.getMemo();
+		this.deliveryStatus = source.getDeliveryStatus();
+		this.deliveryPolicyId = source.getDeliveryPolicyId();
+		this.deliveryDriverId = source.getDeliveryDriverId();
+	}
+}

--- a/src/main/java/com/project/doubleshop/web/delivery/dto/DeliveryPolicyDTO.java
+++ b/src/main/java/com/project/doubleshop/web/delivery/dto/DeliveryPolicyDTO.java
@@ -1,0 +1,41 @@
+package com.project.doubleshop.web.delivery.dto;
+
+import com.project.doubleshop.domain.delivery.entity.DeliveryPolicy;
+import com.project.doubleshop.domain.delivery.entity.FeeMethod;
+import com.project.doubleshop.domain.delivery.entity.FeePolicy;
+
+import lombok.Getter;
+
+@Getter
+public class DeliveryPolicyDTO {
+	// 배송 정책 pk
+	private final Long id;
+
+	// 배송 정책 이름
+	private final String name;
+
+	// 배송사
+	private final String company;
+
+	// 배송비 적용 정책
+	private final FeePolicy feePolicy;
+
+	// 배송비 지불방식
+	private final FeeMethod feeMethod;
+
+	// 배송비
+	private final int feePrice;
+
+	// 산간도서지역비용
+	private final int islandMountainousFee;
+
+	public DeliveryPolicyDTO(DeliveryPolicy source) {
+		this.id = source.getId();
+		this.name = source.getName();
+		this.company = source.getCompany();
+		this.feePolicy = source.getFeePolicy();
+		this.feeMethod = source.getFeeMethod();
+		this.feePrice = source.getFeePrice();
+		this.islandMountainousFee = source.getIslandMountainousFee();
+	}
+}

--- a/src/main/java/com/project/doubleshop/web/delivery/dto/DeliveryPolicyForm.java
+++ b/src/main/java/com/project/doubleshop/web/delivery/dto/DeliveryPolicyForm.java
@@ -1,0 +1,44 @@
+package com.project.doubleshop.web.delivery.dto;
+
+import com.project.doubleshop.domain.delivery.entity.DeliveryPolicy;
+import com.project.doubleshop.domain.delivery.entity.FeeMethod;
+import com.project.doubleshop.domain.delivery.entity.FeePolicy;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeliveryPolicyForm {
+	// 배송 정책 pk
+	private Long id;
+
+	// 배송 정책 이름
+	private String name;
+
+	// 배송사
+	private String company;
+
+	// 배송비 적용 정책
+	private FeePolicy feePolicy;
+
+	// 배송비 지불방식
+	private FeeMethod feeMethod;
+
+	// 배송비
+	private int feePrice;
+
+	// 산간도서지역비용
+	private int islandMountainousFee;
+
+	public DeliveryPolicyForm(DeliveryPolicy source) {
+		this.id = source.getId();
+		this.name = source.getName();
+		this.company = source.getCompany();
+		this.feePolicy = source.getFeePolicy();
+		this.feeMethod = source.getFeeMethod();
+		this.feePrice = source.getFeePrice();
+		this.islandMountainousFee = source.getIslandMountainousFee();
+	}
+}

--- a/src/main/resources/mapper/deliveryDriverMapper.xml
+++ b/src/main/resources/mapper/deliveryDriverMapper.xml
@@ -1,0 +1,34 @@
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.project.doubleshop.domain.delivery.mapper.DeliveryDriverMapper">
+    <insert id="insertDeliveryDriver" parameterType="DeliveryDriver" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO DELIVERY_DRIVER (name, phone, create_time, update_time,
+                                     status, status_update_time)
+        VALUES (#{name}, #{phone}, #{createTime}, #{updateTime},
+                #{status}, #{statusUpdateTime});
+    </insert>
+    <select id="selectByDeliveryDriverId" parameterType="long" resultType="DeliveryDriver">
+        SELECT name, phone, create_time, update_time,
+               status, status_update_time
+        FROM DELIVERY_DRIVER WHERE ID = #{id}
+    </select>
+    <select id="selectAllDeliveryDriver" resultType="DeliveryDriver" parameterType="Pageable">
+        SELECT name, phone, create_time, create_time,
+               status, status_update_time
+        FROM DELIVERY_DRIVER ORDER BY id DESC LIMIT #{size} OFFSET #{page}
+    </select>
+    <update id="updateDeliveryDriver" parameterType="DeliveryDriver">
+        UPDATE DELIVERY_DRIVER SET
+                                    name = #{name},
+                                    phone = #{phone},
+                                    create_time = #{createTime},
+                                    update_time = #{updateTime},
+                                    status = #{status},
+                                    status_update_time = #{statusUpdateTime}
+        WHERE id = #{id}
+    </update>
+    <delete id="deleteDeliveryDriver" parameterType="Status">
+        DELETE FROM DELIVERY_DRIVER WHERE status = #{DELETE}
+    </delete>
+</mapper>

--- a/src/main/resources/mapper/deliveryDriverMapper.xml
+++ b/src/main/resources/mapper/deliveryDriverMapper.xml
@@ -28,6 +28,9 @@
                                     status_update_time = #{statusUpdateTime}
         WHERE id = #{id}
     </update>
+    <update id="updateDeliveryDriverStatus" parameterType="StatusRequest">
+        UPDATE DELIVERY_DRIVER SET status = #{status} WHERE id = #{id}
+    </update>
     <delete id="deleteDeliveryDriver" parameterType="Status">
         DELETE FROM DELIVERY_DRIVER WHERE status = #{TO_BE_DELETED}
     </delete>

--- a/src/main/resources/mapper/deliveryDriverMapper.xml
+++ b/src/main/resources/mapper/deliveryDriverMapper.xml
@@ -29,6 +29,6 @@
         WHERE id = #{id}
     </update>
     <delete id="deleteDeliveryDriver" parameterType="Status">
-        DELETE FROM DELIVERY_DRIVER WHERE status = #{DELETE}
+        DELETE FROM DELIVERY_DRIVER WHERE status = #{TO_BE_DELETED}
     </delete>
 </mapper>

--- a/src/main/resources/mapper/deliveryMapper.xml
+++ b/src/main/resources/mapper/deliveryMapper.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.project.doubleshop.domain.delivery.mapper.DeliveryMapper">
+    <insert id="insertDelivery" parameterType="Delivery" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO DELIVERY (waybill_number, memo, status, status_update_time)
+        VALUES (#{waybillNumber}, #{memo}, #{status}, #{statusUpdateTime})
+    </insert>
+    <select id="selectByDeliveryId" parameterType="long" resultType="Delivery">
+        SELECT id, waybill_number, memo, status, status_update_time
+        FROM DELIVERY WHERE id = #{id}
+    </select>
+    <select id="selectAllDelivery" resultType="Item" parameterType="Pageable">
+        SELECT id, waybill_number, memo, status, status_update_time
+        FROM DELIVERY ORDER BY id DESC LIMIT #{size} OFFSET #{page}
+    </select>
+    <update id="updateDelivery" parameterType="Delivery">
+        UPDATE DELIVERY SET
+                            waybill_number = #{waybillNumber},
+                            memo = #{memo},
+                            status = #{status},
+                            status_update_time = #{statusUpdateTime}
+        WHERE id = #{id}
+    </update>
+    <delete id="deleteDelivery" parameterType="Status">
+        DELETE FROM DELIVERY WHERE status = #{DELETE}
+    </delete>
+</mapper>

--- a/src/main/resources/mapper/deliveryMapper.xml
+++ b/src/main/resources/mapper/deliveryMapper.xml
@@ -4,15 +4,15 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.project.doubleshop.domain.delivery.mapper.DeliveryMapper">
     <insert id="insertDelivery" parameterType="Delivery" useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO DELIVERY (waybill_number, memo, create_time, status, status_update_time)
-        VALUES (#{waybillNumber}, #{memo}, #{createTime}, #{status}, #{statusUpdateTime})
+        INSERT INTO DELIVERY (waybill_number, memo, create_time, status, status_update_time, delivery_policy_id, delivery_driver_id)
+        VALUES (#{waybillNumber}, #{memo}, #{createTime}, #{status}, #{statusUpdateTime}, #{deliveryPolicyId}, #{deliveryDriverId})
     </insert>
     <select id="selectByDeliveryId" parameterType="long" resultType="Delivery">
-        SELECT id, waybill_number, memo, status, create_time, update_time, status_update_time
+        SELECT id, waybill_number, memo, status, create_time, update_time, status_update_time, delivery_policy_id
         FROM DELIVERY WHERE id = #{id}
     </select>
     <select id="selectAllDelivery" resultType="Delivery" parameterType="Pageable">
-        SELECT id, waybill_number, memo, status, create_time, update_time, status_update_time
+        SELECT id, waybill_number, memo, status, create_time, update_time, status_update_time, delivery_policy_id
         FROM DELIVERY ORDER BY id DESC LIMIT #{size} OFFSET #{page}
     </select>
     <update id="updateDelivery" parameterType="Delivery">
@@ -22,10 +22,12 @@
                             create_time = #{createTime},
                             update_time = #{updateTime},
                             status = #{status},
-                            status_update_time = #{statusUpdateTime}
+                            status_update_time = #{statusUpdateTime},
+                            delivery_policy_id = #{deliveryPolicyId},
+                            delivery_driver_id = #{deliveryDriverId}
         WHERE id = #{id}
     </update>
     <delete id="deleteDelivery" parameterType="Status">
-        DELETE FROM DELIVERY WHERE status = #{DELETE}
+        DELETE FROM DELIVERY WHERE status = #{TO_BE_DELETED}
     </delete>
 </mapper>

--- a/src/main/resources/mapper/deliveryMapper.xml
+++ b/src/main/resources/mapper/deliveryMapper.xml
@@ -4,21 +4,23 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.project.doubleshop.domain.delivery.mapper.DeliveryMapper">
     <insert id="insertDelivery" parameterType="Delivery" useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO DELIVERY (waybill_number, memo, status, status_update_time)
-        VALUES (#{waybillNumber}, #{memo}, #{status}, #{statusUpdateTime})
+        INSERT INTO DELIVERY (waybill_number, memo, create_time, status, status_update_time)
+        VALUES (#{waybillNumber}, #{memo}, #{createTime}, #{status}, #{statusUpdateTime})
     </insert>
     <select id="selectByDeliveryId" parameterType="long" resultType="Delivery">
-        SELECT id, waybill_number, memo, status, status_update_time
+        SELECT id, waybill_number, memo, status, create_time, update_time, status_update_time
         FROM DELIVERY WHERE id = #{id}
     </select>
     <select id="selectAllDelivery" resultType="Item" parameterType="Pageable">
-        SELECT id, waybill_number, memo, status, status_update_time
+        SELECT id, waybill_number, memo, status, create_time, update_time, status_update_time
         FROM DELIVERY ORDER BY id DESC LIMIT #{size} OFFSET #{page}
     </select>
     <update id="updateDelivery" parameterType="Delivery">
         UPDATE DELIVERY SET
                             waybill_number = #{waybillNumber},
                             memo = #{memo},
+                            create_time = #{createTime},
+                            update_time = #{updateTime},
                             status = #{status},
                             status_update_time = #{statusUpdateTime}
         WHERE id = #{id}

--- a/src/main/resources/mapper/deliveryMapper.xml
+++ b/src/main/resources/mapper/deliveryMapper.xml
@@ -11,7 +11,7 @@
         SELECT id, waybill_number, memo, status, create_time, update_time, status_update_time
         FROM DELIVERY WHERE id = #{id}
     </select>
-    <select id="selectAllDelivery" resultType="Item" parameterType="Pageable">
+    <select id="selectAllDelivery" resultType="Delivery" parameterType="Pageable">
         SELECT id, waybill_number, memo, status, create_time, update_time, status_update_time
         FROM DELIVERY ORDER BY id DESC LIMIT #{size} OFFSET #{page}
     </select>

--- a/src/main/resources/mapper/deliveryMapper.xml
+++ b/src/main/resources/mapper/deliveryMapper.xml
@@ -4,15 +4,21 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.project.doubleshop.domain.delivery.mapper.DeliveryMapper">
     <insert id="insertDelivery" parameterType="Delivery" useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO DELIVERY (waybill_number, memo, create_time, status, status_update_time, delivery_policy_id, delivery_driver_id)
-        VALUES (#{waybillNumber}, #{memo}, #{createTime}, #{status}, #{statusUpdateTime}, #{deliveryPolicyId}, #{deliveryDriverId})
+        INSERT INTO DELIVERY (waybill_number, memo, create_time, delivery_status,
+                              status, status_update_time, delivery_policy_id, delivery_driver_id)
+        VALUES (#{waybillNumber}, #{memo}, #{createTime}, #{deliveryStatus},
+                #{status}, #{statusUpdateTime}, #{deliveryPolicyId}, #{deliveryDriverId})
     </insert>
     <select id="selectByDeliveryId" parameterType="long" resultType="Delivery">
-        SELECT id, waybill_number, memo, status, create_time, update_time, status_update_time, delivery_policy_id
+        SELECT id, waybill_number, memo, status,
+               create_time, update_time, delivery_status, status_update_time,
+               delivery_policy_id
         FROM DELIVERY WHERE id = #{id}
     </select>
     <select id="selectAllDelivery" resultType="Delivery" parameterType="Pageable">
-        SELECT id, waybill_number, memo, status, create_time, update_time, status_update_time, delivery_policy_id
+        SELECT id, waybill_number, memo, status,
+               create_time, update_time, delivery_status, status_update_time,
+               delivery_policy_id
         FROM DELIVERY ORDER BY id DESC LIMIT #{size} OFFSET #{page}
     </select>
     <update id="updateDelivery" parameterType="Delivery">
@@ -21,6 +27,7 @@
                             memo = #{memo},
                             create_time = #{createTime},
                             update_time = #{updateTime},
+                            delivery_status = #{deliveryStatus},
                             status = #{status},
                             status_update_time = #{statusUpdateTime},
                             delivery_policy_id = #{deliveryPolicyId},

--- a/src/main/resources/mapper/deliveryMapper.xml
+++ b/src/main/resources/mapper/deliveryMapper.xml
@@ -34,6 +34,9 @@
                             delivery_driver_id = #{deliveryDriverId}
         WHERE id = #{id}
     </update>
+    <update id="updateDeliveryStatus" parameterType="StatusRequest">
+        UPDATE DELIVERY SET status = #{status} WHERE id = #{id}
+    </update>
     <delete id="deleteDelivery" parameterType="Status">
         DELETE FROM DELIVERY WHERE status = #{TO_BE_DELETED}
     </delete>

--- a/src/main/resources/mapper/deliveryPolicyMapper.xml
+++ b/src/main/resources/mapper/deliveryPolicyMapper.xml
@@ -1,0 +1,11 @@
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.project.doubleshop.domain.delivery.mapper.DeliveryPolicyMapper">
+    <insert id="insertDeliveryPolicy" parameterType="DeliveryPolicy" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO DELIVERY_POLICY (name, company, fee_policy, fee_method,
+                                     fee_price, island_mountainous_fee)
+        VALUES (#{name}, #{company}, #{feePolicy}, #{feeMethod}, #{feePrice}, #{islandMountainousFee})
+    </insert>
+    <select id=""
+</mapper>

--- a/src/main/resources/mapper/deliveryPolicyMapper.xml
+++ b/src/main/resources/mapper/deliveryPolicyMapper.xml
@@ -28,7 +28,7 @@
                                    status_update_time = #{statusUpdateTime}
         WHERE id = #{id}
     </update>
-    <delete id="deleteDeliveryDriver" parameterType="Status">
+    <delete id="deleteDeliveryPolicy" parameterType="Status">
         DELETE FROM DELIVERY_POLICY WHERE status = #{DELETE}
     </delete>
 </mapper>

--- a/src/main/resources/mapper/deliveryPolicyMapper.xml
+++ b/src/main/resources/mapper/deliveryPolicyMapper.xml
@@ -29,6 +29,6 @@
         WHERE id = #{id}
     </update>
     <delete id="deleteDeliveryPolicy" parameterType="Status">
-        DELETE FROM DELIVERY_POLICY WHERE status = #{DELETE}
+        DELETE FROM DELIVERY_POLICY WHERE status = #{TO_BE_DELETED}
     </delete>
 </mapper>

--- a/src/main/resources/mapper/deliveryPolicyMapper.xml
+++ b/src/main/resources/mapper/deliveryPolicyMapper.xml
@@ -28,6 +28,9 @@
                                    status_update_time = #{statusUpdateTime}
         WHERE id = #{id}
     </update>
+    <update id="updateDeliveryPolicyStatus" parameterType="StatusRequest">
+        UPDATE DELIVERY_POLICY SET status = #{status} WHERE id = #{id}
+    </update>
     <delete id="deleteDeliveryPolicy" parameterType="Status">
         DELETE FROM DELIVERY_POLICY WHERE status = #{TO_BE_DELETED}
     </delete>

--- a/src/main/resources/mapper/deliveryPolicyMapper.xml
+++ b/src/main/resources/mapper/deliveryPolicyMapper.xml
@@ -4,8 +4,31 @@
 <mapper namespace="com.project.doubleshop.domain.delivery.mapper.DeliveryPolicyMapper">
     <insert id="insertDeliveryPolicy" parameterType="DeliveryPolicy" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO DELIVERY_POLICY (name, company, fee_policy, fee_method,
-                                     fee_price, island_mountainous_fee)
-        VALUES (#{name}, #{company}, #{feePolicy}, #{feeMethod}, #{feePrice}, #{islandMountainousFee})
+                                     fee_price, island_mountainous_fee, status, status_update_time)
+        VALUES (#{name}, #{company}, #{feePolicy}, #{feeMethod}, #{feePrice}, #{islandMountainousFee}, #{status}, #{statusUpdateTime})
     </insert>
-    <select id=""
+    <select id="selectByDeliveryPolicy"  parameterType="long" resultType="DeliveryPolicy">
+        SELECT id, name, company, fee_policy, fee_method,
+               fee_price, island_mountainous_fee, status, status_update_time
+        FROM DELIVERY_POLICY WHERE id = #{id}
+    </select>
+    <select id="selectAllDeliveryPolicy" resultType="DeliveryPolicy" parameterType="Pageable">
+        SELECT id, name, company, fee_policy, fee_method,
+               fee_price, island_mountainous_fee, status, status_update_time
+        FROM DELIVERY_POLICY ORDER BY id DESC LIMIT #{size} OFFSET #{page}
+    </select>
+    <update id="updateDeliveryPolicy" parameterType="DeliveryPolicy">
+        UPDATE DELIVERY_POLICY SET
+                                   name = #{name},
+                                   company = #{company},
+                                   fee_policy = #{feePolicy},
+                                   fee_method = #{feeMethod},
+                                   fee_price = #{feePrice},
+                                   status = #{status},
+                                   status_update_time = #{statusUpdateTime}
+        WHERE id = #{id}
+    </update>
+    <delete id="deleteDeliveryDriver" parameterType="Status">
+        DELETE FROM DELIVERY_POLICY WHERE status = #{DELETE}
+    </delete>
 </mapper>

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -17,6 +17,8 @@
         <typeAlias type="com.project.doubleshop.domain.common.mapper.param.RequestItemsWithCategory" alias="RequestItemsWithCategory"/>
         <typeAlias type="com.project.doubleshop.domain.member.entity.Member" alias="Member"/>
         <typeAlias type="com.project.doubleshop.domain.delivery.entity.Delivery" alias="Delivery"/>
+        <typeAlias type="com.project.doubleshop.domain.delivery.entity.DeliveryDriver" alias="DeliveryDriver"/>
+        <typeAlias type="com.project.doubleshop.domain.delivery.entity.DeliveryPolicy" />
     </typeAliases>
     <typeHandlers>
         <typeHandler handler="com.project.doubleshop.domain.common.StatusTypeHandler" />
@@ -26,5 +28,6 @@
         <mapper resource="mapper/categoryMapper.xml"/>
         <mapper resource="mapper/authenticationMemberMapper.xml"/>
         <mapper resource="mapper/deliveryMapper.xml"/>
+        <mapper resource="mapper/deliveryPolicyMapper.xml"/>
     </mappers>
 </configuration>

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -24,6 +24,7 @@
         <typeHandler handler="com.project.doubleshop.domain.common.StatusTypeHandler" />
         <typeHandler handler="com.project.doubleshop.domain.delivery.entity.FeeMethodTypeHandler"/>
         <typeHandler handler="com.project.doubleshop.domain.delivery.entity.FeePolicyTypeHandler"/>
+        <typeHandler handler="com.project.doubleshop.domain.delivery.entity.DeliveryStatusTypeHandler"/>
     </typeHandlers>
     <mappers>
         <mapper resource="mapper/itemMapper.xml"/>

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -16,6 +16,7 @@
         <typeAlias type="com.project.doubleshop.domain.category.entity.DepthLevel" alias="DepthLevel"/>
         <typeAlias type="com.project.doubleshop.domain.common.mapper.param.RequestItemsWithCategory" alias="RequestItemsWithCategory"/>
         <typeAlias type="com.project.doubleshop.domain.member.entity.Member" alias="Member"/>
+        <typeAlias type="com.project.doubleshop.domain.delivery.entity.Delivery" alias="Delivery"/>
     </typeAliases>
     <typeHandlers>
         <typeHandler handler="com.project.doubleshop.domain.common.StatusTypeHandler" />
@@ -24,5 +25,6 @@
         <mapper resource="mapper/itemMapper.xml"/>
         <mapper resource="mapper/categoryMapper.xml"/>
         <mapper resource="mapper/authenticationMemberMapper.xml"/>
+        <mapper resource="mapper/deliveryMapper.xml"/>
     </mappers>
 </configuration>

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -22,12 +22,15 @@
     </typeAliases>
     <typeHandlers>
         <typeHandler handler="com.project.doubleshop.domain.common.StatusTypeHandler" />
+        <typeHandler handler="com.project.doubleshop.domain.delivery.entity.FeeMethodTypeHandler"/>
+        <typeHandler handler="com.project.doubleshop.domain.delivery.entity.FeePolicyTypeHandler"/>
     </typeHandlers>
     <mappers>
         <mapper resource="mapper/itemMapper.xml"/>
         <mapper resource="mapper/categoryMapper.xml"/>
         <mapper resource="mapper/authenticationMemberMapper.xml"/>
         <mapper resource="mapper/deliveryMapper.xml"/>
+        <mapper resource="mapper/deliveryDriverMapper.xml"/>
         <mapper resource="mapper/deliveryPolicyMapper.xml"/>
     </mappers>
 </configuration>

--- a/src/test/java/com/project/doubleshop/domain/delivery/service/DeliveryDriverServiceTest.java
+++ b/src/test/java/com/project/doubleshop/domain/delivery/service/DeliveryDriverServiceTest.java
@@ -1,0 +1,80 @@
+package com.project.doubleshop.domain.delivery.service;
+
+import static com.project.doubleshop.domain.delivery.service.MockDelivery.DeliveryDriver1.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.project.doubleshop.domain.delivery.entity.DeliveryDriver;
+import com.project.doubleshop.domain.delivery.repository.DeliveryDriverRepository;
+import com.project.doubleshop.web.config.support.Pageable;
+import com.project.doubleshop.web.item.exception.DataNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+class DeliveryDriverServiceTest {
+
+	@Mock
+	DeliveryDriverRepository deliveryDriverRepository;
+
+	@Mock
+	Pageable pageable;
+
+	@InjectMocks
+	DeliveryDriverService deliveryDriverService;
+
+	@Test
+	@DisplayName("배송기사 등록 성공")
+	void saveDeliveryDriver() {
+		given(deliveryDriverRepository.save(DELIVERY_DRIVER_FORM)).willReturn(true);
+
+		boolean result = deliveryDriverService.saveDeliveryDriver(DELIVERY_DRIVER_FORM);
+
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("배송기사 단건 조회 성공")
+	void findOneDeliveryPolicy() {
+		given(deliveryDriverRepository.findById(ID)).willReturn(DELIVERY_DRIVER_1);
+
+		DeliveryDriver deliveryDriver = deliveryDriverService.findById(ID);
+
+		assertThat(deliveryDriver.getId()).isEqualTo(ID);
+	}
+
+	@Test
+	@DisplayName("배송기사 조회 실패")
+	void findOneDeliveryPolicyFail() {
+		given(deliveryDriverRepository.findById(ID)).willReturn(null);
+
+		assertThrows(DataNotFoundException.class, () -> deliveryDriverService.findById(ID));
+	}
+
+	@Test
+	@DisplayName("배송기사 수정 성공")
+	void updateDeliveryPolicy() {
+		given(deliveryDriverRepository.findById(ID)).willReturn(DELIVERY_DRIVER_1);
+		given(deliveryDriverRepository.save(DELIVERY_DRIVER_1)).willReturn(true);
+
+		deliveryDriverService.saveDeliveryDriver(DELIVERY_DRIVER_1, ID);
+
+		then(deliveryDriverRepository).should(times(1)).save(DELIVERY_DRIVER_1);
+	}
+
+	@Test
+	@DisplayName("배송기사 목록 조회 성공")
+	void findAllDeliveryPolicies() {
+		given(deliveryDriverRepository.findAll(pageable)).willReturn(anyList());
+
+		deliveryDriverService.findDeliverDrivers(pageable);
+
+		then(deliveryDriverRepository).should(times(1)).findAll(pageable);
+	}
+}

--- a/src/test/java/com/project/doubleshop/domain/delivery/service/DeliveryPolicyServiceTest.java
+++ b/src/test/java/com/project/doubleshop/domain/delivery/service/DeliveryPolicyServiceTest.java
@@ -1,0 +1,80 @@
+package com.project.doubleshop.domain.delivery.service;
+
+import static com.project.doubleshop.domain.delivery.service.MockDelivery.DeliveryPolicy1.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.project.doubleshop.domain.delivery.entity.DeliveryPolicy;
+import com.project.doubleshop.domain.delivery.repository.DeliveryPolicyRepository;
+import com.project.doubleshop.web.config.support.Pageable;
+import com.project.doubleshop.web.item.exception.DataNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+class DeliveryPolicyServiceTest {
+
+	@Mock
+	DeliveryPolicyRepository deliveryPolicyRepository;
+
+	@Mock
+	Pageable pageable;
+
+	@InjectMocks
+	DeliveryPolicyService deliveryPolicyService;
+
+	@Test
+	@DisplayName("배송정책 등록 성공")
+	void saveDeliveryPolicy() {
+		given(deliveryPolicyRepository.save(DELIVERY_POLICY_FORM)).willReturn(true);
+
+		boolean result = deliveryPolicyService.saveDeliveryPolicy(DELIVERY_POLICY_FORM);
+
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("배송정책 단건 조회 성공")
+	void findOneDeliveryPolicy() {
+		given(deliveryPolicyRepository.findById(ID)).willReturn(DELIVERY_POLICY_1);
+
+		DeliveryPolicy result = deliveryPolicyService.findById(ID);
+
+		assertThat(result.getId()).isEqualTo(ID);
+	}
+
+	@Test
+	@DisplayName("배송정책 조회 실패")
+	void findOneDeliveryPolicyFail() {
+		given(deliveryPolicyRepository.findById(ID)).willReturn(null);
+
+		assertThrows(DataNotFoundException.class, () -> deliveryPolicyService.findById(ID));
+	}
+
+	@Test
+	@DisplayName("배송정책 수정 성공")
+	void updateDeliveryPolicy() {
+		given(deliveryPolicyRepository.findById(ID)).willReturn(DELIVERY_POLICY_1);
+		given(deliveryPolicyRepository.save(DELIVERY_POLICY_1)).willReturn(true);
+
+		deliveryPolicyService.saveDeliveryPolicy(DELIVERY_POLICY_1, ID);
+
+		then(deliveryPolicyRepository).should(times(1)).save(DELIVERY_POLICY_1);
+	}
+
+	@Test
+	@DisplayName("배송정책 목록 조회 성공")
+	void findAllDeliveryPolicies() {
+		given(deliveryPolicyRepository.findAll(pageable)).willReturn(anyList());
+
+		deliveryPolicyService.findDeliveryPolicies(pageable);
+
+		then(deliveryPolicyRepository).should(times(1)).findAll(pageable);
+	}
+}

--- a/src/test/java/com/project/doubleshop/domain/delivery/service/DeliveryServiceTest.java
+++ b/src/test/java/com/project/doubleshop/domain/delivery/service/DeliveryServiceTest.java
@@ -32,10 +32,9 @@ class DeliveryServiceTest {
 	@Test
 	@DisplayName("배송등록 성공")
 	void saveDelivery() {
-		Delivery deliveryForm = mock(Delivery.class);
-		given(deliveryRepository.save(deliveryForm)).willReturn(true);
+		given(deliveryRepository.save(DELIVERY_FORM)).willReturn(true);
 
-		boolean result = deliveryService.saveDelivery(deliveryForm);
+		boolean result = deliveryService.saveDelivery(DELIVERY_FORM);
 
 		assertThat(result).isTrue();
 	}
@@ -61,16 +60,17 @@ class DeliveryServiceTest {
 	@Test
 	@DisplayName("배송 수정 성공")
 	void updateDelivery() {
-		given(deliveryRepository.findById(DELIVERY_1.getId())).willReturn(DELIVERY_1);
+		given(deliveryRepository.findById(ID)).willReturn(DELIVERY_1);
 		given(deliveryRepository.save(DELIVERY_1)).willReturn(true);
 
-		deliveryService.saveDelivery(DELIVERY_1, DELIVERY_1.getId());
+		deliveryService.saveDelivery(DELIVERY_1, ID);
 
 		then(deliveryRepository).should(times(1)).save(DELIVERY_1);
 	}
 
 	@Test
-	void findAllDelivery() {
+	@DisplayName("배송 목록 조회 성공")
+	void findAllDeliveries() {
 		given(deliveryRepository.findAll(pageable)).willReturn(anyList());
 
 		deliveryService.findDeliveries(pageable);

--- a/src/test/java/com/project/doubleshop/domain/delivery/service/DeliveryServiceTest.java
+++ b/src/test/java/com/project/doubleshop/domain/delivery/service/DeliveryServiceTest.java
@@ -1,0 +1,80 @@
+package com.project.doubleshop.domain.delivery.service;
+
+import static com.project.doubleshop.domain.delivery.service.MockDelivery.Delivery1.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.project.doubleshop.domain.delivery.entity.Delivery;
+import com.project.doubleshop.domain.delivery.repository.DeliveryRepository;
+import com.project.doubleshop.web.config.support.Pageable;
+import com.project.doubleshop.web.item.exception.DataNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+class DeliveryServiceTest {
+
+	@Mock
+	DeliveryRepository deliveryRepository;
+
+	@Mock
+	Pageable pageable;
+
+	@InjectMocks
+	DeliveryService deliveryService;
+
+	@Test
+	@DisplayName("배송등록 성공")
+	void saveDelivery() {
+		Delivery deliveryForm = mock(Delivery.class);
+		given(deliveryRepository.save(deliveryForm)).willReturn(true);
+
+		boolean result = deliveryService.saveDelivery(deliveryForm);
+
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("배송 단건 조회 성공")
+	void findOneDelivery() {
+		given(deliveryRepository.findById(ID)).willReturn(DELIVERY_1);
+
+		Delivery result = deliveryService.findById(ID);
+
+		assertThat(result.getId()).isEqualTo(ID);
+	}
+
+	@Test
+	@DisplayName("배송 조회 실패")
+	void findOneDeliveryFail() {
+		given(deliveryRepository.findById(ID)).willReturn(null);
+
+		assertThrows(DataNotFoundException.class, () -> deliveryService.findById(ID));
+	}
+
+	@Test
+	@DisplayName("배송 수정 성공")
+	void updateDelivery() {
+		given(deliveryRepository.findById(DELIVERY_1.getId())).willReturn(DELIVERY_1);
+		given(deliveryRepository.save(DELIVERY_1)).willReturn(true);
+
+		deliveryService.saveDelivery(DELIVERY_1, DELIVERY_1.getId());
+
+		then(deliveryRepository).should(times(1)).save(DELIVERY_1);
+	}
+
+	@Test
+	void findAllDelivery() {
+		given(deliveryRepository.findAll(pageable)).willReturn(anyList());
+
+		deliveryService.findDeliveries(pageable);
+
+		then(deliveryRepository).should(times(1)).findAll(pageable);
+	}
+}

--- a/src/test/java/com/project/doubleshop/domain/delivery/service/MockDelivery.java
+++ b/src/test/java/com/project/doubleshop/domain/delivery/service/MockDelivery.java
@@ -1,0 +1,68 @@
+package com.project.doubleshop.domain.delivery.service;
+
+import java.time.LocalDateTime;
+
+import com.project.doubleshop.domain.common.Status;
+import com.project.doubleshop.domain.delivery.entity.Delivery;
+import com.project.doubleshop.domain.delivery.entity.DeliveryPolicy;
+import com.project.doubleshop.domain.delivery.entity.DeliveryStatus;
+import com.project.doubleshop.domain.delivery.entity.FeeMethod;
+import com.project.doubleshop.domain.delivery.entity.FeePolicy;
+
+public class MockDelivery {
+	public static class Delivery1 {
+		public static final Long ID = 1L;
+		public static final String WAYBILL_NUMBER = "110232-123223-9909";
+		public static final String MEMO = "배송도착 시 현관문 앞에 놓아주세요.";
+		public static final LocalDateTime CREATE_TIME = LocalDateTime.of(2021, 12, 13, 9, 27, 1);
+		public static final LocalDateTime UPDATE_TIME = null;
+		public static final DeliveryStatus DELIVERY_STATUS = DeliveryStatus.PRODUCT_PREPARATION;
+		public static final Status STATUS = Status.ACTIVATED;
+		public static final LocalDateTime STATUS_UPDATE_TIME = CREATE_TIME;
+		public static final Long DELIVERY_POLICY_ID = DeliveryPolicy1.ID;
+		public static final Long DELIVERY_DRIVER_ID = DeliveryDriver1.ID;
+
+		public static final Delivery DELIVERY_1 = Delivery.builder()
+			.id(ID)
+			.waybillNumber(WAYBILL_NUMBER)
+			.memo(MEMO)
+			.createTime(CREATE_TIME)
+			.updateTime(UPDATE_TIME)
+			.deliveryStatus(DELIVERY_STATUS)
+			.status(STATUS)
+			.statusUpdateTime(STATUS_UPDATE_TIME)
+			.deliveryPolicyId(DELIVERY_POLICY_ID)
+			.deliveryDriverId(DELIVERY_DRIVER_ID)
+			.build();
+
+		public static final Delivery DELIVERY_FORM = Delivery.builder()
+			.waybillNumber(WAYBILL_NUMBER)
+			.memo(MEMO)
+			.createTime(CREATE_TIME)
+			.deliveryStatus(DELIVERY_STATUS)
+			.status(STATUS)
+			.build();
+	}
+
+	public static class DeliveryPolicy1 {
+		public static final Long ID = 1L;
+		public static final String NAME = "기본정책";
+		public static final String COMPANY = "배송사이름";
+		public static final FeePolicy FEE_POLICY = FeePolicy.FREE;
+		public static final FeeMethod FEE_METHOD = FeeMethod.PREPAID;
+		public static final int FEE_PRICE = 0;
+		public static final int ISLAND_MOUNTAINOUS_FEE = 2700;
+		public static final Status STATUS = Status.ACTIVATED;
+		public static final LocalDateTime STATUS_UPDATE_TIME = LocalDateTime.of(2021, 11, 13, 9, 27, 1);
+	}
+
+	public static class DeliveryDriver1 {
+		public static final Long ID = 1L;
+		public static final String NAME = "김기사";
+		public static final String PHONE = "010-1234-5678";
+		public static final LocalDateTime CREATE_TIME = LocalDateTime.of(2021, 10, 13, 9, 27, 1);
+		public static final LocalDateTime UPDATE_TIME = null;
+		public static final Status STATUS = Status.ACTIVATED;
+		public static final LocalDateTime STATUS_UPDATE_TIME = CREATE_TIME;
+	}
+}

--- a/src/test/java/com/project/doubleshop/domain/delivery/service/MockDelivery.java
+++ b/src/test/java/com/project/doubleshop/domain/delivery/service/MockDelivery.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import com.project.doubleshop.domain.common.Status;
 import com.project.doubleshop.domain.delivery.entity.Delivery;
+import com.project.doubleshop.domain.delivery.entity.DeliveryDriver;
 import com.project.doubleshop.domain.delivery.entity.DeliveryPolicy;
 import com.project.doubleshop.domain.delivery.entity.DeliveryStatus;
 import com.project.doubleshop.domain.delivery.entity.FeeMethod;
@@ -54,6 +55,28 @@ public class MockDelivery {
 		public static final int ISLAND_MOUNTAINOUS_FEE = 2700;
 		public static final Status STATUS = Status.ACTIVATED;
 		public static final LocalDateTime STATUS_UPDATE_TIME = LocalDateTime.of(2021, 11, 13, 9, 27, 1);
+
+		public static final DeliveryPolicy DELIVERY_POLICY_1 = DeliveryPolicy.builder()
+			.id(ID)
+			.name(NAME)
+			.company(COMPANY)
+			.feePolicy(FEE_POLICY)
+			.feeMethod(FEE_METHOD)
+			.feePrice(FEE_PRICE)
+			.islandMountainousFee(ISLAND_MOUNTAINOUS_FEE)
+			.status(STATUS)
+			.statusUpdateTime(STATUS_UPDATE_TIME)
+			.build();
+
+		public static final DeliveryPolicy DELIVERY_POLICY_FORM = DeliveryPolicy.builder()
+			.name(NAME)
+			.company(COMPANY)
+			.feePolicy(FEE_POLICY)
+			.feeMethod(FEE_METHOD)
+			.feePrice(FEE_PRICE)
+			.islandMountainousFee(ISLAND_MOUNTAINOUS_FEE)
+			.status(STATUS)
+			.build();
 	}
 
 	public static class DeliveryDriver1 {
@@ -64,5 +87,22 @@ public class MockDelivery {
 		public static final LocalDateTime UPDATE_TIME = null;
 		public static final Status STATUS = Status.ACTIVATED;
 		public static final LocalDateTime STATUS_UPDATE_TIME = CREATE_TIME;
+
+		public static final DeliveryDriver DELIVERY_DRIVER_1 = DeliveryDriver.builder()
+			.id(ID)
+			.name(NAME)
+			.phone(PHONE)
+			.createTime(CREATE_TIME)
+			.updateTime(UPDATE_TIME)
+			.status(STATUS)
+			.statusUpdateTime(STATUS_UPDATE_TIME)
+			.build();
+
+		public static final DeliveryDriver DELIVERY_DRIVER_FORM = DeliveryDriver.builder()
+			.name(NAME)
+			.phone(PHONE)
+			.createTime(CREATE_TIME)
+			.status(STATUS)
+			.build();
 	}
 }

--- a/src/test/resources/test/schema.sql
+++ b/src/test/resources/test/schema.sql
@@ -61,5 +61,7 @@ CREATE TABLE IF NOT EXISTS MEMBER (
 CREATE TABLE IF NOT EXISTS DELIVERY (
   id                           BIGSERIAL      NOT NULL,
   waybill_number               VARCHAR(50)    NOT NULL,
-  memo                         VARCHAR(255)   NOT NULL
+  memo                         VARCHAR(255)   NOT NULL,
+  status                       INTEGER        DEFAULT 2001,
+  status_update_time           TIMESTAMP      NULL DEFAULT NOW()
 );

--- a/src/test/resources/test/schema.sql
+++ b/src/test/resources/test/schema.sql
@@ -62,6 +62,7 @@ CREATE TABLE IF NOT EXISTS DELIVERY (
     memo                       VARCHAR(255)   NOT NULL,
     create_time                TIMESTAMP      NULL DEFAULT NOW(),
     update_time                TIMESTAMP      NULL DEFAULT NOW(),
+    delivery_status            INTEGER        DEFAULT 4001,
     status                     INTEGER        DEFAULT 2001,
     status_update_time         TIMESTAMP      NULL DEFAULT NOW(),
     delivery_policy_id         BIGINT         DEFAULT NULL,

--- a/src/test/resources/test/schema.sql
+++ b/src/test/resources/test/schema.sql
@@ -57,3 +57,9 @@ CREATE TABLE IF NOT EXISTS MEMBER (
     status_update_time         TIMESTAMP      NULL DEFAULT NOW(),
     create_time                TIMESTAMP      NULL DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS DELIVERY (
+  id                           BIGSERIAL      NOT NULL,
+  waybill_num                  VARCHAR(50)    NOT NULL,
+  memo                         VARCHAR(255)   NOT NULL
+);

--- a/src/test/resources/test/schema.sql
+++ b/src/test/resources/test/schema.sql
@@ -26,8 +26,7 @@ CREATE TABLE  IF NOT EXISTS ITEM
     status                     INTEGER        DEFAULT 2001,
     status_update_time         TIMESTAMP      DEFAULT NOW(),
     created_time               TIMESTAMP      DEFAULT NOW(),
-    category_id                BIGINT         DEFAULT NULL,
-    CONSTRAINT PK_ITEM PRIMARY KEY (id)
+    category_id                BIGINT         DEFAULT NULL
 );
 
 CREATE TABLE  IF NOT EXISTS CATEGORY
@@ -38,8 +37,7 @@ CREATE TABLE  IF NOT EXISTS CATEGORY
     depth_level                VARCHAR(50)    NULL DEFAULT 'DEPTH_ONE',
     is_refundable              BOOLEAN        NULL DEFAULT FALSE,
     status                     INTEGER        DEFAULT 2001,
-    status_update_time         TIMESTAMP      NULL DEFAULT NOW(),
-    CONSTRAINT PK_CATEGORY PRIMARY KEY (id)
+    status_update_time         TIMESTAMP      NULL DEFAULT NOW()
 );
 
 ALTER TABLE ITEM ADD CONSTRAINT FK_CATEGORY FOREIGN KEY (category_id) REFERENCES CATEGORY (id);
@@ -65,7 +63,9 @@ CREATE TABLE IF NOT EXISTS DELIVERY (
     create_time                TIMESTAMP      NULL DEFAULT NOW(),
     update_time                TIMESTAMP      NULL DEFAULT NOW(),
     status                     INTEGER        DEFAULT 2001,
-    status_update_time         TIMESTAMP      NULL DEFAULT NOW()
+    status_update_time         TIMESTAMP      NULL DEFAULT NOW(),
+    delivery_policy_id         BIGINT         DEFAULT NULL,
+    delivery_driver_id         BIGINT         DEFAULT NULL
 );
 
 CREATE TABLE IF NOT EXISTS DELIVERY_DRIVER (
@@ -89,3 +89,6 @@ CREATE TABLE IF NOT EXISTS DELIVERY_POLICY (
     status                     INTEGER        DEFAULT 2001,
     status_update_time         TIMESTAMP      NULL DEFAULT NOW()
 );
+
+ALTER TABLE DELIVERY ADD CONSTRAINT FK_DELIVERY_POLICY FOREIGN KEY (delivery_policy_id) REFERENCES DELIVERY_POLICY (id);
+ALTER TABLE DELIVERY ADD CONSTRAINT FK_DELIVERY_DRIVER FOREIGN KEY (delivery_driver_id) REFERENCES DELIVERY_DRIVER (id);

--- a/src/test/resources/test/schema.sql
+++ b/src/test/resources/test/schema.sql
@@ -60,6 +60,6 @@ CREATE TABLE IF NOT EXISTS MEMBER (
 
 CREATE TABLE IF NOT EXISTS DELIVERY (
   id                           BIGSERIAL      NOT NULL,
-  waybill_num                  VARCHAR(50)    NOT NULL,
+  waybill_number               VARCHAR(50)    NOT NULL,
   memo                         VARCHAR(255)   NOT NULL
 );

--- a/src/test/resources/test/schema.sql
+++ b/src/test/resources/test/schema.sql
@@ -59,11 +59,33 @@ CREATE TABLE IF NOT EXISTS MEMBER (
 );
 
 CREATE TABLE IF NOT EXISTS DELIVERY (
-  id                           BIGSERIAL      NOT NULL,
-  waybill_number               VARCHAR(50)    NOT NULL,
-  memo                         VARCHAR(255)   NOT NULL,
-  create_time                  TIMESTAMP      NULL DEFAULT NOW(),
-  update_time                  TIMESTAMP      NULL DEFAULT NOW(),
-  status                       INTEGER        DEFAULT 2001,
-  status_update_time           TIMESTAMP      NULL DEFAULT NOW()
+    id                         BIGSERIAL      NOT NULL,
+    waybill_number             VARCHAR(50)    NOT NULL,
+    memo                       VARCHAR(255)   NOT NULL,
+    create_time                TIMESTAMP      NULL DEFAULT NOW(),
+    update_time                TIMESTAMP      NULL DEFAULT NOW(),
+    status                     INTEGER        DEFAULT 2001,
+    status_update_time         TIMESTAMP      NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS DELIVERY_DRIVER (
+    id                         BIGSERIAL      NOT NULL,
+    name                       VARCHAR(50)    NOT NULL,
+    phone                      VARCHAR(50)    NOT NULL,
+    create_time                TIMESTAMP      NULL DEFAULT NOW(),
+    update_time                TIMESTAMP      NULL DEFAULT NOW(),
+    status                     INTEGER        DEFAULT 2001,
+    status_update_time         TIMESTAMP      NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS DELIVERY_POLICY (
+    id                         BIGSERIAL      NOT NULL,
+    name                       VARCHAR(50)    NOT NULL,
+    company                    VARCHAR(50)    NOT NULL,
+    fee_policy                 INTEGER        DEFAULT 1002,
+    fee_method                 INTEGER        DEFAULT 7270,
+    fee_price                  INTEGER        NOT NULL,
+    island_mountainous_fee     INTEGER        NOT NULL,
+    status                     INTEGER        DEFAULT 2001,
+    status_update_time         TIMESTAMP      NULL DEFAULT NOW()
 );

--- a/src/test/resources/test/schema.sql
+++ b/src/test/resources/test/schema.sql
@@ -62,6 +62,8 @@ CREATE TABLE IF NOT EXISTS DELIVERY (
   id                           BIGSERIAL      NOT NULL,
   waybill_number               VARCHAR(50)    NOT NULL,
   memo                         VARCHAR(255)   NOT NULL,
+  create_time                  TIMESTAMP      NULL DEFAULT NOW(),
+  update_time                  TIMESTAMP      NULL DEFAULT NOW(),
   status                       INTEGER        DEFAULT 2001,
   status_update_time           TIMESTAMP      NULL DEFAULT NOW()
 );


### PR DESCRIPTION
## 개요
배송 도메인과 관련된 CRUD api (배송 관리, 배송 정책, 배송 기사) 구현
## Description
### 배송 관리
- 주문 접수 이후, 할당되는 배송 서비스
- 하나의 배송 정책과 한 명의 배송 기사 할당
- `상품 준비`, `배송 준비`, `배송 보류`, `배송중`, `배송완료` 와 같은 배송 프로세스의 세부 단계를 관리한다.
### 배송 정책
- 하나의 배송에 할당되는 정책
- `배송사`, `배송비 지불방식`과 `지불정책` 관리
- `배송비 지불 방식`과 `배송비 지불 정책`의 차이
    - 지불 방식은 배송비를 배송 시작 전에 미리 지불할지(선불), 혹은 물건을 받고 지불할지(착불)의 여부
    - 지불 정책은 배송비 부과에 대한 정책을 관리하는 필드로, `무료 배송`, 혹은 `조건부 무료 배송`, `주문 당 배송비 부과`로 분류한다.
### 특이사항
`배송 프로세스 관리 로직`의 경우, 현재 팀원이 작업 중인 도메인에 의존할 수 밖에 없는 상황이라, 조율이 필요할 듯 하여, 이 부분에 대한 작업은 보류함.