### PR TITLE
소비자 주문 서비스 API

### DIFF
--- a/src/main/java/com/project/doubleshop/domain/address/Address.java
+++ b/src/main/java/com/project/doubleshop/domain/address/Address.java
@@ -1,4 +1,4 @@
-package com.project.doubleshop.domain.order.entity;
+package com.project.doubleshop.domain.address;
 
 import java.time.LocalDateTime;
 
@@ -14,19 +14,18 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
-public class Order {
-
+public class Address {
 	private Long id;
 
-	private LocalDateTime orderedTime;
+	private String city;
 
-	private Integer orderStatus;
+	private String zipcode;
 
-	private Integer orderType;
-
-	private Integer totalPrice;
+	private String detail;
 
 	private Status status;
 
 	private LocalDateTime statusUpdateTime;
+
+	private Long memberId;
 }

--- a/src/main/java/com/project/doubleshop/domain/address/entity/Address.java
+++ b/src/main/java/com/project/doubleshop/domain/address/entity/Address.java
@@ -1,4 +1,4 @@
-package com.project.doubleshop.domain.address;
+package com.project.doubleshop.domain.address.entity;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/project/doubleshop/domain/address/mapper/AddressMapper.java
+++ b/src/main/java/com/project/doubleshop/domain/address/mapper/AddressMapper.java
@@ -1,0 +1,15 @@
+package com.project.doubleshop.domain.address.mapper;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.project.doubleshop.domain.address.entity.Address;
+
+public interface AddressMapper {
+	int insertAddress(Address address);
+	List<Address> selectByMemberId(Long memberId);
+	Address selectAddressById(Long id);
+	int updateStatus(Integer statusCode, LocalDateTime statusUpdateTime, List<Long> addressIds);
+	int updateAddress(Address address);
+	int deleteAddress(Integer statusCode);
+}

--- a/src/main/java/com/project/doubleshop/domain/address/mapper/AddressMapper.java
+++ b/src/main/java/com/project/doubleshop/domain/address/mapper/AddressMapper.java
@@ -3,13 +3,16 @@ package com.project.doubleshop.domain.address.mapper;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.apache.ibatis.annotations.Mapper;
+
 import com.project.doubleshop.domain.address.entity.Address;
 
+@Mapper
 public interface AddressMapper {
 	int insertAddress(Address address);
-	List<Address> selectByMemberId(Long memberId);
+	List<Address> selectAddressByMemberId(Long memberId);
 	Address selectAddressById(Long id);
-	int updateStatus(Integer statusCode, LocalDateTime statusUpdateTime, List<Long> addressIds);
+	int updateAddressStatus(Integer statusCode, LocalDateTime statusUpdateTime, List<Long> addressIds);
 	int updateAddress(Address address);
 	int deleteAddress(Integer statusCode);
 }

--- a/src/main/java/com/project/doubleshop/domain/address/repository/AddressRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/address/repository/AddressRepository.java
@@ -1,0 +1,19 @@
+package com.project.doubleshop.domain.address.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.project.doubleshop.domain.address.entity.Address;
+import com.project.doubleshop.domain.common.Status;
+
+public interface AddressRepository {
+	boolean save(Address address);
+
+	List<Address> findByMemberId(Long memberId);
+
+	Address findById(Long id);
+
+	Integer updateStatus(Integer statusCode, LocalDateTime statusUpdateTime, List<Long> addressIds);
+
+	Integer deleteAddress(Status status);
+}

--- a/src/main/java/com/project/doubleshop/domain/address/repository/MyBatisAddressRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/address/repository/MyBatisAddressRepository.java
@@ -30,7 +30,7 @@ public class MyBatisAddressRepository implements AddressRepository {
 
 	@Override
 	public List<Address> findByMemberId(Long memberId) {
-		return mapper.selectByMemberId(memberId);
+		return mapper.selectAddressByMemberId(memberId);
 	}
 
 	@Override
@@ -40,7 +40,7 @@ public class MyBatisAddressRepository implements AddressRepository {
 
 	@Override
 	public Integer updateStatus(Integer statusCode, LocalDateTime statusUpdateTime, List<Long> addressIds) {
-		return mapper.updateStatus(statusCode, statusUpdateTime, addressIds);
+		return mapper.updateAddressStatus(statusCode, statusUpdateTime, addressIds);
 	}
 
 	@Override

--- a/src/main/java/com/project/doubleshop/domain/address/repository/MyBatisAddressRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/address/repository/MyBatisAddressRepository.java
@@ -1,0 +1,50 @@
+package com.project.doubleshop.domain.address.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.project.doubleshop.domain.address.entity.Address;
+import com.project.doubleshop.domain.address.mapper.AddressMapper;
+import com.project.doubleshop.domain.common.Status;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MyBatisAddressRepository implements AddressRepository {
+
+	private final AddressMapper mapper;
+
+	@Override
+	public boolean save(Address address) {
+		int affectedRowCnt = 0;
+		if (address.getId() != null) {
+			affectedRowCnt = mapper.updateAddress(address);
+		} else {
+			affectedRowCnt = mapper.insertAddress(address);
+		}
+		return affectedRowCnt != 0;
+	}
+
+	@Override
+	public List<Address> findByMemberId(Long memberId) {
+		return mapper.selectByMemberId(memberId);
+	}
+
+	@Override
+	public Address findById(Long id) {
+		return mapper.selectAddressById(id);
+	}
+
+	@Override
+	public Integer updateStatus(Integer statusCode, LocalDateTime statusUpdateTime, List<Long> addressIds) {
+		return mapper.updateStatus(statusCode, statusUpdateTime, addressIds);
+	}
+
+	@Override
+	public Integer deleteAddress(Status status) {
+		return mapper.deleteAddress(status.getValue());
+	}
+}

--- a/src/main/java/com/project/doubleshop/domain/cart/service/CartService.java
+++ b/src/main/java/com/project/doubleshop/domain/cart/service/CartService.java
@@ -12,6 +12,7 @@ import com.project.doubleshop.domain.cart.entity.Cart;
 import com.project.doubleshop.domain.cart.repository.CartRepository;
 import com.project.doubleshop.domain.item.entity.Item;
 import com.project.doubleshop.domain.item.service.ItemService;
+import com.project.doubleshop.domain.utils.ExceptionUtils;
 import com.project.doubleshop.web.item.exception.InvalidArgumentException;
 
 import lombok.RequiredArgsConstructor;
@@ -36,38 +37,28 @@ public class CartService {
 
 	@Transactional
 	public Integer deleteCarts(Long memberId, List<Long> cartIds) {
-		List<Cart> carts = cartRepository.findCartInIds(cartIds, memberId);
-		if (cartIds.size() != carts.size()) {
-			// 파라미터로 전달 받은 id들 중에서 검색이 안된 장바구니가 있다면, 예외를 던진다.
-			findInvalidIdsAndThrowException(carts, cartIds);
-		}
+		findCartsInCartIds(cartIds, memberId);
 		return cartRepository.deleteCarts(memberId, cartIds);
 	}
 
-	private void findInvalidIdsAndThrowException(List<Cart> carts, List<Long> cartIds) {
-		StringBuilder sb = new StringBuilder();
+	public List<Cart> findCartsInCartIds(List<Long> cartIds, Long memberId) {
+		List<Cart> carts = cartRepository.findCartInIds(cartIds, memberId);
+		if (cartIds.size() != carts.size()) {
+			// 파라미터로 전달 받은 id들 중에서 검색이 안된 장바구니가 있다면, 예외를 던진다.
+			// 검색결과로 받은 장바구니 id 들을 수집하여, 파라미터로 전달된 장바구니 id 중에서 검색이 안된 장바구니 id를 예외로 전달한다.
+			Set<Long> validIds = carts
+				.stream()
+				.map(Cart::getId)
+				.collect(Collectors.toSet());
 
-		// 검색결과로 받은 장바구니 id 들을 수집하여, 파라미터로 전달된 장바구니 id 중에서 검색이 안된 장바구니 id를 예외로 전달한다.
-		Set<Long> validIds = carts
-			.stream()
-			.map(Cart::getId)
-			.collect(Collectors.toSet());
-		List<Long> invalidIds = cartIds
-			.stream()
-			.filter(id -> !validIds.contains(id))
-			.collect(Collectors.toList());
+			List<Long> invalidIds = cartIds
+				.stream()
+				.filter(id -> !validIds.contains(id))
+				.collect(Collectors.toList());
 
-		sb.append("Invalid cart id [");
-		for (int i = 0; i < invalidIds.size(); i++) {
-			sb.append(invalidIds.get(i));
-			if (i < invalidIds.size() - 1) {
-				sb.append(", ");
-			} else {
-				sb.append("]");
-			}
+			ExceptionUtils.findInvalidIdsAndThrowException(invalidIds, "Invalid cart id");
 		}
-
-		throw new IllegalArgumentException(sb.toString());
+		return carts;
 	}
 
 	@Transactional

--- a/src/main/java/com/project/doubleshop/domain/item/mapper/ItemMapper.java
+++ b/src/main/java/com/project/doubleshop/domain/item/mapper/ItemMapper.java
@@ -9,14 +9,25 @@ import com.project.doubleshop.domain.common.mapper.param.RequestItemsWithCategor
 import com.project.doubleshop.domain.item.entity.Item;
 import com.project.doubleshop.web.config.support.Pageable;
 import com.project.doubleshop.web.common.StatusRequest;
+import com.project.doubleshop.web.item.dto.ItemStockQuery;
 
 @Mapper
 public interface ItemMapper {
     int insertItem(Item item);
+
     Item selectByItemId(Long id);
+
     List<Item> selectAllItems(Pageable pageable);
+
     List<Item> selectItemsWithCategory(RequestItemsWithCategory request);
+
     int updateItem(Item item);
+
     int updateItemStatus(StatusRequest statusRequest);
+
     int deleteItem(Status status);
+
+    List<Item> selectItemsInIds(List<Long> itemIds);
+
+    int batchUpdateItems(List<ItemStockQuery> queryList);
 }

--- a/src/main/java/com/project/doubleshop/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/item/repository/ItemRepository.java
@@ -7,6 +7,7 @@ import com.project.doubleshop.domain.common.mapper.param.RequestItemsWithCategor
 import com.project.doubleshop.domain.item.entity.Item;
 import com.project.doubleshop.web.config.support.Pageable;
 import com.project.doubleshop.web.common.StatusRequest;
+import com.project.doubleshop.web.item.dto.ItemStockQuery;
 
 public interface ItemRepository extends Manageable<StatusRequest> {
 	/**
@@ -36,4 +37,8 @@ public interface ItemRepository extends Manageable<StatusRequest> {
 	 * @return 특정 카테고리로 정리된 상품 Collection
 	 */
 	List<Item> findAllWithCategory(RequestItemsWithCategory request);
+
+	List<Item> findItemsInIds(List<Long> itemIds);
+
+	int updateItems(List<ItemStockQuery> queryList);
 }

--- a/src/main/java/com/project/doubleshop/domain/item/repository/MyBatisItemRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/item/repository/MyBatisItemRepository.java
@@ -10,6 +10,7 @@ import com.project.doubleshop.domain.item.entity.Item;
 import com.project.doubleshop.domain.item.mapper.ItemMapper;
 import com.project.doubleshop.web.config.support.Pageable;
 import com.project.doubleshop.web.common.StatusRequest;
+import com.project.doubleshop.web.item.dto.ItemStockQuery;
 
 import lombok.RequiredArgsConstructor;
 
@@ -43,6 +44,16 @@ public class MyBatisItemRepository implements ItemRepository {
 	@Override
 	public List<Item> findAllWithCategory(RequestItemsWithCategory request) {
 		return mapper.selectItemsWithCategory(request);
+	}
+
+	@Override
+	public List<Item> findItemsInIds(List<Long> itemIds) {
+		return mapper.selectItemsInIds(itemIds);
+	}
+
+	@Override
+	public int updateItems(List<ItemStockQuery> queryList) {
+		return mapper.batchUpdateItems(queryList);
 	}
 
 	@Override

--- a/src/main/java/com/project/doubleshop/domain/order/entity/Order.java
+++ b/src/main/java/com/project/doubleshop/domain/order/entity/Order.java
@@ -3,6 +3,7 @@ package com.project.doubleshop.domain.order.entity;
 import java.time.LocalDateTime;
 
 import com.project.doubleshop.domain.common.Status;
+import com.project.doubleshop.web.order.dto.OrderForm;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -33,4 +34,16 @@ public class Order {
 	private Long addressId;
 
 	private Long memberId;
+
+	public static Order convertToOrder(OrderForm orderForm) {
+		return Order.builder()
+			.orderedTime(orderForm.getOrderedTime())
+			.orderStatus(orderForm.getOrderStatus())
+			.totalPrice(orderForm.getTotalPrice())
+			.status(orderForm.getStatus())
+			.statusUpdateTime(orderForm.getStatusUpdateTime())
+			.addressId(orderForm.getAddressId())
+			.memberId(orderForm.getMemberId())
+			.build();
+	}
 }

--- a/src/main/java/com/project/doubleshop/domain/order/entity/Order.java
+++ b/src/main/java/com/project/doubleshop/domain/order/entity/Order.java
@@ -29,4 +29,8 @@ public class Order {
 	private Status status;
 
 	private LocalDateTime statusUpdateTime;
+
+	private Long addressId;
+
+	private Long memberId;
 }

--- a/src/main/java/com/project/doubleshop/domain/order/entity/OrderDetail.java
+++ b/src/main/java/com/project/doubleshop/domain/order/entity/OrderDetail.java
@@ -1,9 +1,5 @@
 package com.project.doubleshop.domain.order.entity;
 
-import java.time.LocalDateTime;
-
-import com.project.doubleshop.domain.common.Status;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,19 +10,12 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
-public class Order {
-
+public class OrderDetail {
 	private Long id;
 
-	private LocalDateTime orderedTime;
+	private Integer quantity;
 
-	private Integer orderStatus;
+	private Integer price;
 
-	private Integer orderType;
-
-	private Integer totalPrice;
-
-	private Status status;
-
-	private LocalDateTime statusUpdateTime;
+	private Long itemId;
 }

--- a/src/main/java/com/project/doubleshop/domain/order/entity/constant/OrderConstant.java
+++ b/src/main/java/com/project/doubleshop/domain/order/entity/constant/OrderConstant.java
@@ -1,0 +1,6 @@
+package com.project.doubleshop.domain.order.entity.constant;
+
+public class OrderConstant {
+	public static final int ORDERED = 1000;
+	public static final int CANCELED = 1001;
+}

--- a/src/main/java/com/project/doubleshop/domain/order/mapper/OrderDetailMapper.java
+++ b/src/main/java/com/project/doubleshop/domain/order/mapper/OrderDetailMapper.java
@@ -11,9 +11,9 @@ import com.project.doubleshop.web.order.dto.OrderDetailResult;
 @Mapper
 public interface OrderDetailMapper {
 	int insertOrderDetail(OrderDetail orderDetail);
-	List<OrderDetail> selectByOrderId(Long orderId);
-	List<OrderDetailResult> selectWithItemByOrderId(Long orderId);
-	int updateStatus(int statusCode, LocalDateTime statusUpdateTime, List<Long> orderIds);
+	List<OrderDetail> selectOrderDetailByOrderId(Long orderId);
+	List<OrderDetailResult> selectOrderDetailWithItemByOrderId(Long orderId);
+	int updateOrderDetailStatus(int statusCode, LocalDateTime statusUpdateTime, List<Long> orderIds);
 	int deleteOrderDetails(Integer statusCode);
 	int batchInsertOrderDetails(List<OrderDetail> orderDetails);
 }

--- a/src/main/java/com/project/doubleshop/domain/order/mapper/OrderDetailMapper.java
+++ b/src/main/java/com/project/doubleshop/domain/order/mapper/OrderDetailMapper.java
@@ -1,0 +1,18 @@
+package com.project.doubleshop.domain.order.mapper;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.project.doubleshop.domain.order.entity.OrderDetail;
+import com.project.doubleshop.web.order.dto.OrderDetailResult;
+
+@Mapper
+public interface OrderDetailMapper {
+	int insertOrderDetail(OrderDetail orderDetail);
+	List<OrderDetail> selectByOrderId(Long orderId);
+	List<OrderDetailResult> selectWithItemByOrderId(Long orderId);
+	int updateStatus(int statusCode, LocalDateTime statusUpdateTime, List<Long> orderIds);
+	int deleteOrderDetails(Integer statusCode);
+}

--- a/src/main/java/com/project/doubleshop/domain/order/mapper/OrderDetailMapper.java
+++ b/src/main/java/com/project/doubleshop/domain/order/mapper/OrderDetailMapper.java
@@ -15,4 +15,5 @@ public interface OrderDetailMapper {
 	List<OrderDetailResult> selectWithItemByOrderId(Long orderId);
 	int updateStatus(int statusCode, LocalDateTime statusUpdateTime, List<Long> orderIds);
 	int deleteOrderDetails(Integer statusCode);
+	int batchInsertOrderDetails(List<OrderDetail> orderDetails);
 }

--- a/src/main/java/com/project/doubleshop/domain/order/mapper/OrderMapper.java
+++ b/src/main/java/com/project/doubleshop/domain/order/mapper/OrderMapper.java
@@ -12,6 +12,7 @@ import java.util.List;
 public interface OrderMapper {
     int insertOrder(Order order);
     Order selectByOrderId(Long id);
+    Order selectByIdAndMemberId(Long id, Long memberId);
     List<Order> selectByMemberId(Long memberId, Integer size, Long page);
     int updateOrderStatus(OrderStatusRequest orderStatusRequest);
     int updateStatus(Integer statusCode, LocalDateTime statusUpdateTime, List<Long> orderIds);

--- a/src/main/java/com/project/doubleshop/domain/order/mapper/OrderMapper.java
+++ b/src/main/java/com/project/doubleshop/domain/order/mapper/OrderMapper.java
@@ -11,8 +11,8 @@ import java.util.List;
 @Mapper
 public interface OrderMapper {
     int insertOrder(Order order);
-    Order selectByOrderId(Long id);
-    Order selectByIdAndMemberId(Long id, Long memberId);
+    Order selectOrderByOrderId(Long id);
+    Order selectOrderByIdAndMemberId(Long id, Long memberId);
     List<Order> selectByMemberId(Long memberId, Integer size, Long page);
     int updateOrderStatus(OrderStatusRequest orderStatusRequest);
     int updateStatus(Integer statusCode, LocalDateTime statusUpdateTime, List<Long> orderIds);

--- a/src/main/java/com/project/doubleshop/domain/order/mapper/OrderMapper.java
+++ b/src/main/java/com/project/doubleshop/domain/order/mapper/OrderMapper.java
@@ -1,14 +1,19 @@
 package com.project.doubleshop.domain.order.mapper;
 
 import com.project.doubleshop.domain.order.entity.Order;
+import com.project.doubleshop.web.order.dto.OrderStatusRequest;
+
 import org.apache.ibatis.annotations.Mapper;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Mapper
 public interface OrderMapper {
     int insertOrder(Order order);
     Order selectByOrderId(Long id);
-    List<Order> selectAll();
-    int updateOrder(Order order);
+    List<Order> selectByMemberId(Long memberId, Integer size, Long page);
+    int updateOrderStatus(OrderStatusRequest orderStatusRequest);
+    int updateStatus(Integer statusCode, LocalDateTime statusUpdateTime, List<Long> orderIds);
+    int deleteOrders(Integer statusCode);
 }

--- a/src/main/java/com/project/doubleshop/domain/order/repository/MyBatisOrderDetailRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/order/repository/MyBatisOrderDetailRepository.java
@@ -41,4 +41,9 @@ public class MyBatisOrderDetailRepository implements OrderDetailRepository {
 	public Integer deleteOrderDetails(Status status) {
 		return mapper.deleteOrderDetails(status.getValue());
 	}
+
+	@Override
+	public Integer batchInsert(List<OrderDetail> orderDetails) {
+		return mapper.batchInsertOrderDetails(orderDetails);
+	}
 }

--- a/src/main/java/com/project/doubleshop/domain/order/repository/MyBatisOrderDetailRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/order/repository/MyBatisOrderDetailRepository.java
@@ -1,0 +1,44 @@
+package com.project.doubleshop.domain.order.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.project.doubleshop.domain.common.Status;
+import com.project.doubleshop.domain.order.entity.OrderDetail;
+import com.project.doubleshop.domain.order.mapper.OrderDetailMapper;
+import com.project.doubleshop.web.order.dto.OrderDetailResult;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MyBatisOrderDetailRepository implements OrderDetailRepository {
+	private final OrderDetailMapper mapper;
+
+	@Override
+	public boolean save(OrderDetail orderDetail) {
+		return mapper.insertOrderDetail(orderDetail) != 0;
+	}
+
+	@Override
+	public List<OrderDetail> findById(Long orderId) {
+		return mapper.selectByOrderId(orderId);
+	}
+
+	@Override
+	public List<OrderDetailResult> findWithItemByOrderId(Long orderId) {
+		return mapper.selectWithItemByOrderId(orderId);
+	}
+
+	@Override
+	public Integer updateStatus(Integer statusCode, LocalDateTime statusUpdateTime, List<Long> orderIds) {
+		return mapper.updateStatus(statusCode, statusUpdateTime, orderIds);
+	}
+
+	@Override
+	public Integer deleteOrderDetails(Status status) {
+		return mapper.deleteOrderDetails(status.getValue());
+	}
+}

--- a/src/main/java/com/project/doubleshop/domain/order/repository/MyBatisOrderDetailRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/order/repository/MyBatisOrderDetailRepository.java
@@ -24,17 +24,17 @@ public class MyBatisOrderDetailRepository implements OrderDetailRepository {
 
 	@Override
 	public List<OrderDetail> findById(Long orderId) {
-		return mapper.selectByOrderId(orderId);
+		return mapper.selectOrderDetailByOrderId(orderId);
 	}
 
 	@Override
 	public List<OrderDetailResult> findWithItemByOrderId(Long orderId) {
-		return mapper.selectWithItemByOrderId(orderId);
+		return mapper.selectOrderDetailWithItemByOrderId(orderId);
 	}
 
 	@Override
 	public Integer updateStatus(Integer statusCode, LocalDateTime statusUpdateTime, List<Long> orderIds) {
-		return mapper.updateStatus(statusCode, statusUpdateTime, orderIds);
+		return mapper.updateOrderDetailStatus(statusCode, statusUpdateTime, orderIds);
 	}
 
 	@Override

--- a/src/main/java/com/project/doubleshop/domain/order/repository/MyBatisOrderRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/order/repository/MyBatisOrderRepository.java
@@ -26,12 +26,12 @@ public class MyBatisOrderRepository implements OrderRepository {
 
 	@Override
 	public Order findById(Long id) {
-		return mapper.selectByOrderId(id);
+		return mapper.selectOrderByOrderId(id);
 	}
 
 	@Override
 	public Order findByIdAndMemberId(Long id, Long memberId) {
-		return mapper.selectByIdAndMemberId(id, memberId);
+		return mapper.selectOrderByIdAndMemberId(id, memberId);
 	}
 
 	@Override

--- a/src/main/java/com/project/doubleshop/domain/order/repository/MyBatisOrderRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/order/repository/MyBatisOrderRepository.java
@@ -17,35 +17,40 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MyBatisOrderRepository implements OrderRepository {
 
-	private final OrderMapper orderMapper;
+	private final OrderMapper mapper;
 
 	@Override
 	public boolean save(Order order) {
-		return orderMapper.insertOrder(order) != 0;
+		return mapper.insertOrder(order) != 0;
 	}
 
 	@Override
 	public Order findById(Long id) {
-		return orderMapper.selectByOrderId(id);
+		return mapper.selectByOrderId(id);
+	}
+
+	@Override
+	public Order findByIdAndMemberId(Long id, Long memberId) {
+		return mapper.selectByIdAndMemberId(id, memberId);
 	}
 
 	@Override
 	public List<Order> findByMemberId(Long memberId, Pageable pageable) {
-		return orderMapper.selectByMemberId(memberId, pageable.size(), pageable.page());
+		return mapper.selectByMemberId(memberId, pageable.size(), pageable.page());
 	}
 
 	@Override
 	public Integer updateOrderStatus(OrderStatusRequest orderStatusRequest) {
-		return orderMapper.updateOrderStatus(orderStatusRequest);
+		return mapper.updateOrderStatus(orderStatusRequest);
 	}
 
 	@Override
 	public Integer updateStatus(Integer statusCode, LocalDateTime statusUpdateTime, List<Long> orderIds) {
-		return orderMapper.updateStatus(statusCode, statusUpdateTime, orderIds);
+		return mapper.updateStatus(statusCode, statusUpdateTime, orderIds);
 	}
 
 	@Override
 	public Integer deleteOrders(Status status) {
-		return orderMapper.deleteOrders(status.getValue());
+		return mapper.deleteOrders(status.getValue());
 	}
 }

--- a/src/main/java/com/project/doubleshop/domain/order/repository/MyBatisOrderRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/order/repository/MyBatisOrderRepository.java
@@ -1,0 +1,51 @@
+package com.project.doubleshop.domain.order.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.project.doubleshop.domain.common.Status;
+import com.project.doubleshop.domain.order.entity.Order;
+import com.project.doubleshop.domain.order.mapper.OrderMapper;
+import com.project.doubleshop.web.config.support.Pageable;
+import com.project.doubleshop.web.order.dto.OrderStatusRequest;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MyBatisOrderRepository implements OrderRepository {
+
+	private final OrderMapper orderMapper;
+
+	@Override
+	public boolean save(Order order) {
+		return orderMapper.insertOrder(order) != 0;
+	}
+
+	@Override
+	public Order findById(Long id) {
+		return orderMapper.selectByOrderId(id);
+	}
+
+	@Override
+	public List<Order> findByMemberId(Long memberId, Pageable pageable) {
+		return orderMapper.selectByMemberId(memberId, pageable.size(), pageable.page());
+	}
+
+	@Override
+	public Integer updateOrderStatus(OrderStatusRequest orderStatusRequest) {
+		return orderMapper.updateOrderStatus(orderStatusRequest);
+	}
+
+	@Override
+	public Integer updateStatus(Integer statusCode, LocalDateTime statusUpdateTime, List<Long> orderIds) {
+		return orderMapper.updateStatus(statusCode, statusUpdateTime, orderIds);
+	}
+
+	@Override
+	public Integer deleteOrders(Status status) {
+		return orderMapper.deleteOrders(status.getValue());
+	}
+}

--- a/src/main/java/com/project/doubleshop/domain/order/repository/OrderDetailRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/order/repository/OrderDetailRepository.java
@@ -1,0 +1,20 @@
+package com.project.doubleshop.domain.order.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.project.doubleshop.domain.common.Status;
+import com.project.doubleshop.domain.order.entity.OrderDetail;
+import com.project.doubleshop.web.order.dto.OrderDetailResult;
+
+public interface OrderDetailRepository {
+	boolean save(OrderDetail orderDetail);
+
+	List<OrderDetail> findById(Long orderId);
+
+	List<OrderDetailResult> findWithItemByOrderId(Long orderId);
+
+	Integer updateStatus(Integer statusCode, LocalDateTime statusUpdateTime, List<Long> orderIds);
+
+	Integer deleteOrderDetails(Status status);
+}

--- a/src/main/java/com/project/doubleshop/domain/order/repository/OrderDetailRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/order/repository/OrderDetailRepository.java
@@ -17,4 +17,6 @@ public interface OrderDetailRepository {
 	Integer updateStatus(Integer statusCode, LocalDateTime statusUpdateTime, List<Long> orderIds);
 
 	Integer deleteOrderDetails(Status status);
+
+	Integer batchInsert(List<OrderDetail> orderDetails);
 }

--- a/src/main/java/com/project/doubleshop/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/order/repository/OrderRepository.java
@@ -13,6 +13,8 @@ public interface OrderRepository {
 
     Order findById(Long id);
 
+    Order findByIdAndMemberId(Long id, Long memberId);
+
     List<Order> findByMemberId(Long memberId, Pageable pageable);
 
     Integer updateOrderStatus(OrderStatusRequest orderStatusRequest);

--- a/src/main/java/com/project/doubleshop/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/project/doubleshop/domain/order/repository/OrderRepository.java
@@ -1,18 +1,23 @@
 package com.project.doubleshop.domain.order.repository;
 
+import com.project.doubleshop.domain.common.Status;
 import com.project.doubleshop.domain.order.entity.Order;
-import org.springframework.data.domain.Pageable;
+import com.project.doubleshop.web.config.support.Pageable;
+import com.project.doubleshop.web.order.dto.OrderStatusRequest;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface OrderRepository {
-
     boolean save(Order order);
 
     Order findById(Long id);
 
-    List<Order> findAll(String userId, Pageable pageable);
+    List<Order> findByMemberId(Long memberId, Pageable pageable);
 
-    Long count(String userId);
+    Integer updateOrderStatus(OrderStatusRequest orderStatusRequest);
 
+    Integer updateStatus(Integer statusCode, LocalDateTime statusUpdateTime, List<Long> orderIds);
+
+    Integer deleteOrders(Status status);
 }

--- a/src/main/java/com/project/doubleshop/domain/order/service/OrderService.java
+++ b/src/main/java/com/project/doubleshop/domain/order/service/OrderService.java
@@ -37,7 +37,7 @@ public class OrderService {
 	private final OrderRepository orderRepository;
 	private final OrderDetailRepository orderDetailRepository;
 	private final AddressRepository addressRepository;
-
+	/*핵심 로직 */
 	@Transactional
 	public Order createOrder(Long memberId, Order order) {
 
@@ -68,7 +68,7 @@ public class OrderService {
 	}
 
 	@Transactional
-	public void cancelOrder(Long memberId, Long orderId) {
+	public Order cancelOrder(Long memberId, Long orderId) {
 		Order order = findByOrderIdAndMemberId(orderId, memberId);
 
 		List<OrderDetailResult> orderDetailWithItems = orderDetailRepository.findWithItemByOrderId(orderId);
@@ -89,8 +89,16 @@ public class OrderService {
 		updateOrderStatus(memberId, orderId, OrderConstant.CANCELED);
 
 		updateItemStockBeforeOrder(quantityPerItem, pricePerItem, items);
+
+		return order;
 	}
 
+	@Transactional
+	public List<OrderDetailResult> searchMyOrders(Long memberId, Long orderId) {
+		return orderDetailRepository.findWithItemByOrderId(orderId);;
+	}
+
+	/* 비 핵심 */
 	@Transactional
 	public void updateOrderStatus(Long memberId, Long orderId, int canceled) {
 		LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/com/project/doubleshop/domain/order/service/OrderService.java
+++ b/src/main/java/com/project/doubleshop/domain/order/service/OrderService.java
@@ -115,15 +115,15 @@ public class OrderService {
 		return orderRepository.save(order);
 	}
 
-	public boolean insertBatch(List<OrderDetail> orderDetails) {
+	@Transactional
+	public void insertBatch(List<OrderDetail> orderDetails) {
 		Integer resultCnt = orderDetailRepository.batchInsert(orderDetails);
 		if (resultCnt == null || resultCnt != orderDetails.size()) {
 			if (resultCnt == null) {
 				throw new NullPointerException("'NullPointerException' occurred while batch insert orderDetails");
 			} else {
-				return false;
+				throw new IllegalArgumentException("Batch insert OrderDetail fail due to invalid orderDetails.");
 			}
 		}
-		return true;
 	}
 }

--- a/src/main/java/com/project/doubleshop/domain/order/service/OrderService.java
+++ b/src/main/java/com/project/doubleshop/domain/order/service/OrderService.java
@@ -1,17 +1,113 @@
 package com.project.doubleshop.domain.order.service;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.project.doubleshop.domain.address.repository.AddressRepository;
+import com.project.doubleshop.domain.cart.entity.Cart;
+import com.project.doubleshop.domain.cart.service.CartService;
+import com.project.doubleshop.domain.common.Status;
+import com.project.doubleshop.domain.item.entity.Item;
+import com.project.doubleshop.domain.item.service.ItemService;
+import com.project.doubleshop.domain.order.entity.Order;
+import com.project.doubleshop.domain.order.entity.OrderDetail;
 import com.project.doubleshop.domain.order.repository.OrderDetailRepository;
 import com.project.doubleshop.domain.order.repository.OrderRepository;
+import com.project.doubleshop.domain.utils.ExceptionUtils;
+import com.project.doubleshop.web.item.dto.ItemStockQuery;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class OrderService {
+	private final CartService cartService;
+	private final ItemService itemService;
 	private final OrderRepository orderRepository;
 	private final OrderDetailRepository orderDetailRepository;
 	private final AddressRepository addressRepository;
+
+	public void createOrder(Long memberId, Order order) {
+
+		List<Cart> carts = cartService.findCartsByMemberId(memberId);
+
+		List<Long> itemIds = new ArrayList<>();
+		Map<Long, Integer> quantityPerItem = new HashMap<>();
+		Map<Long, Integer> pricePerItem = new HashMap<>();
+
+		for (Cart cart : carts) {
+			Long itemId = cart.getItemId();
+			itemIds.add(itemId);
+			quantityPerItem.put(itemId, cart.getQuantity());
+		}
+
+		List<Item> items = itemService.findItemsInItemIds(itemIds);
+		List<Long> invalidItemIds = new ArrayList<>();
+		List<ItemStockQuery> queryList = new ArrayList<>();
+		for (Item item : items) {
+			Long itemId = item.getId();
+			Integer itemStock = item.getStock();
+			Integer cartItemQuantity = quantityPerItem.get(itemId);
+			if (cartItemQuantity > itemStock) {
+				invalidItemIds.add(itemId);
+			} else {
+				queryList.add(new ItemStockQuery(itemId, itemStock - cartItemQuantity));
+				pricePerItem.put(itemId, item.getPrice());
+			}
+		}
+
+		if (invalidItemIds.size() != 0) {
+			// 재고가 없는 상품이 발생하여 예외처리
+			ExceptionUtils.findInvalidIdsAndThrowException(invalidItemIds, "Out of stock item id");
+		}
+		itemService.updateItems(queryList);
+
+		Order newOrder = saveAndGetOrder(order);
+
+		List<OrderDetail> orderDetails = new ArrayList<>();
+		Long orderId = newOrder.getId();
+		LocalDateTime now = LocalDateTime.now();
+		for (Long itemId : itemIds) {
+			Integer quantity = quantityPerItem.get(itemId);
+			Integer price = pricePerItem.get(itemId);
+			orderDetails.add(new OrderDetail(orderId, itemId, quantity, price, Status.ACTIVATED, now));
+		}
+
+		insertBatch(orderDetails);
+	}
+
+	@Transactional
+	public Order saveAndGetOrder(Order order) {
+		if (saveOrder(order)) {
+			return order;
+		} else {
+			throw new NullPointerException("Insert and get order fail");
+		}
+	}
+
+	@Transactional
+	public boolean saveOrder(Order order) {
+		return orderRepository.save(order);
+	}
+
+	public boolean insertBatch(List<OrderDetail> orderDetails) {
+		Integer resultCnt = orderDetailRepository.batchInsert(orderDetails);
+		if (resultCnt == null || resultCnt != orderDetails.size()) {
+			if (resultCnt == null) {
+				throw new NullPointerException("'NullPointerException' occurred while batch insert orderDetails");
+			} else {
+				return false;
+			}
+		}
+		return true;
+	}
 }

--- a/src/main/java/com/project/doubleshop/domain/order/service/OrderService.java
+++ b/src/main/java/com/project/doubleshop/domain/order/service/OrderService.java
@@ -1,0 +1,17 @@
+package com.project.doubleshop.domain.order.service;
+
+import org.springframework.stereotype.Service;
+
+import com.project.doubleshop.domain.address.repository.AddressRepository;
+import com.project.doubleshop.domain.order.repository.OrderDetailRepository;
+import com.project.doubleshop.domain.order.repository.OrderRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+	private final OrderRepository orderRepository;
+	private final OrderDetailRepository orderDetailRepository;
+	private final AddressRepository addressRepository;
+}

--- a/src/main/java/com/project/doubleshop/domain/order/service/OrderService.java
+++ b/src/main/java/com/project/doubleshop/domain/order/service/OrderService.java
@@ -86,23 +86,28 @@ public class OrderService {
 
 		List<Item> items = itemService.findItemsInItemIds(itemIds);
 
-		updateOrderStatus(memberId, orderId, OrderConstant.CANCELED);
-
-		updateItemStockBeforeOrder(quantityPerItem, pricePerItem, items);
+		if (updateOrderStatus(memberId, orderId, OrderConstant.CANCELED)) {
+			updateItemStockBeforeOrder(quantityPerItem, pricePerItem, items);
+		}
 
 		return order;
 	}
 
 	@Transactional
 	public List<OrderDetailResult> searchMyOrders(Long memberId, Long orderId) {
-		return orderDetailRepository.findWithItemByOrderId(orderId);;
+		return orderDetailRepository.findWithItemByOrderId(orderId);
 	}
 
 	/* 비 핵심 */
 	@Transactional
-	public void updateOrderStatus(Long memberId, Long orderId, int canceled) {
+	public Boolean updateOrderStatus(Long memberId, Long orderId, int canceled) {
 		LocalDateTime now = LocalDateTime.now();
-		orderRepository.updateOrderStatus(new OrderStatusRequest(orderId, canceled, now, memberId));
+		Integer resultCnt = orderRepository.updateOrderStatus(new OrderStatusRequest(orderId, canceled, now, memberId));
+		if (resultCnt == 1) {
+			return true;
+		} else {
+			throw new IllegalArgumentException("Request update order cancel fail.");
+		}
 	}
 
 	@Transactional

--- a/src/main/java/com/project/doubleshop/domain/utils/ExceptionUtils.java
+++ b/src/main/java/com/project/doubleshop/domain/utils/ExceptionUtils.java
@@ -1,0 +1,22 @@
+package com.project.doubleshop.domain.utils;
+
+import java.util.List;
+
+public class ExceptionUtils {
+	public static void findInvalidIdsAndThrowException(List<Long> invalidIds, String message) {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append(message);
+		sb.append(" [");
+		for (int i = 0; i < invalidIds.size(); i++) {
+			sb.append(invalidIds.get(i));
+			if (i < invalidIds.size() - 1) {
+				sb.append(", ");
+			} else {
+				sb.append("]");
+			}
+		}
+
+		throw new IllegalArgumentException(sb.toString());
+	}
+}

--- a/src/main/java/com/project/doubleshop/web/cart/controller/CartRestController.java
+++ b/src/main/java/com/project/doubleshop/web/cart/controller/CartRestController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.project.doubleshop.domain.cart.entity.Cart;
@@ -35,10 +36,11 @@ public class CartRestController {
 	}
 
 	@PostMapping("member/{memberId}/cart/{itemId}")
-	public ResponseEntity<CartDto> saveNewCart(@PathVariable Long memberId, @PathVariable Long itemId) {
+	public ResponseEntity<CartDto> saveNewCart(@PathVariable Long memberId, @PathVariable Long itemId, @RequestParam Integer quantity) {
 		Cart cart = Cart.builder()
 			.memberId(memberId)
 			.itemId(itemId)
+			.quantity(quantity)
 			.build();
 		return ResponseEntity.ok(new CartDto(cartService.saveNewCart(cart)));
 	}

--- a/src/main/java/com/project/doubleshop/web/item/dto/ItemStockQuery.java
+++ b/src/main/java/com/project/doubleshop/web/item/dto/ItemStockQuery.java
@@ -1,0 +1,15 @@
+package com.project.doubleshop.web.item.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class ItemStockQuery {
+	private Long itemId;
+	private Integer stock;
+}

--- a/src/main/java/com/project/doubleshop/web/order/OrderRestController.java
+++ b/src/main/java/com/project/doubleshop/web/order/OrderRestController.java
@@ -1,0 +1,61 @@
+package com.project.doubleshop.web.order;
+
+import static java.util.stream.Collectors.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.project.doubleshop.domain.order.entity.Order;
+import com.project.doubleshop.domain.order.service.OrderService;
+import com.project.doubleshop.web.config.support.Pageable;
+import com.project.doubleshop.web.order.dto.OrderDetailDto;
+import com.project.doubleshop.web.order.dto.OrderDetailResult;
+import com.project.doubleshop.web.order.dto.OrderDto;
+import com.project.doubleshop.web.order.dto.OrderForm;
+import com.project.doubleshop.web.order.dto.OrderItemDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("api")
+@RequiredArgsConstructor
+public class OrderRestController {
+
+	private final OrderService orderService;
+
+	@PostMapping("member/{memberId}/order")
+	public ResponseEntity<OrderDto> createNewOrder(@PathVariable Long memberId, @RequestBody OrderForm orderForm) {
+		Order order = orderService.createOrder(memberId, Order.convertToOrder(orderForm));
+		return ResponseEntity.ok(new OrderDto(order));
+	}
+
+	@GetMapping("member/{memberId}/order")
+	public ResponseEntity<List<OrderDto>> findMyOrders(@PathVariable Long memberId, Pageable pageable) {
+		List<Order> orders = orderService.findOrderByMemberId(memberId, pageable);
+		return ResponseEntity.ok(
+			orders.stream()
+				.map(OrderDto::new)
+				.collect(toList()));
+	}
+
+	@GetMapping("member/{memberId}/order/{orderId}")
+	public ResponseEntity<OrderDetailDto> findMyOrderDetail(@PathVariable Long memberId, @PathVariable Long orderId) {
+		return ResponseEntity.ok(orderService.findOrderDetail(memberId, orderId));
+	}
+
+	@PatchMapping("member/{memberId}/order/{orderId}")
+	public ResponseEntity<OrderDto> cancelOrder(@PathVariable Long memberId, @PathVariable Long orderId) {
+		return ResponseEntity.ok(new OrderDto(orderService.cancelOrder(memberId, orderId)));
+	}
+}

--- a/src/main/java/com/project/doubleshop/web/order/dto/OrderDetailDto.java
+++ b/src/main/java/com/project/doubleshop/web/order/dto/OrderDetailDto.java
@@ -1,5 +1,7 @@
 package com.project.doubleshop.web.order.dto;
 
+import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,16 +10,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
-public class OrderDetailResult {
+public class OrderDetailDto {
 	private Long orderId;
 
-	private Long itemId;
-
-	private String name;
-
-	private Integer price;
-
-	private Integer stock;
-
-	private Integer quantity;
+	private List<OrderItemDto> orderItems;
 }

--- a/src/main/java/com/project/doubleshop/web/order/dto/OrderDetailResult.java
+++ b/src/main/java/com/project/doubleshop/web/order/dto/OrderDetailResult.java
@@ -18,4 +18,6 @@ public class OrderDetailResult {
 	Integer price;
 
 	Integer stock;
+
+	Integer quantity;
 }

--- a/src/main/java/com/project/doubleshop/web/order/dto/OrderDetailResult.java
+++ b/src/main/java/com/project/doubleshop/web/order/dto/OrderDetailResult.java
@@ -1,0 +1,21 @@
+package com.project.doubleshop.web.order.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class OrderDetailResult {
+	private Long orderId;
+
+	private Long itemId;
+
+	String name;
+
+	Integer price;
+
+	Integer stock;
+}

--- a/src/main/java/com/project/doubleshop/web/order/dto/OrderDto.java
+++ b/src/main/java/com/project/doubleshop/web/order/dto/OrderDto.java
@@ -1,0 +1,38 @@
+package com.project.doubleshop.web.order.dto;
+
+import java.time.LocalDateTime;
+
+import com.project.doubleshop.domain.common.Status;
+import com.project.doubleshop.domain.order.entity.Order;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OrderDto {
+
+	private final Long id;
+
+	private final LocalDateTime orderedTime;
+
+	private final Integer orderStatus;
+
+	private final Integer orderType;
+
+	private final Integer totalPrice;
+
+	private final Long addressId;
+
+	private final Long memberId;
+
+	public OrderDto(Order order) {
+		this.id = order.getId();
+		this.orderedTime = order.getOrderedTime();
+		this.orderStatus = order.getOrderStatus();
+		this.orderType = order.getOrderType();
+		this.totalPrice = order.getTotalPrice();
+		this.addressId = order.getAddressId();
+		this.memberId = order.getMemberId();
+	}
+}

--- a/src/main/java/com/project/doubleshop/web/order/dto/OrderForm.java
+++ b/src/main/java/com/project/doubleshop/web/order/dto/OrderForm.java
@@ -1,0 +1,29 @@
+package com.project.doubleshop.web.order.dto;
+
+import java.time.LocalDateTime;
+
+import com.project.doubleshop.domain.common.Status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OrderForm {
+
+	private final LocalDateTime orderedTime;
+
+	private final Integer orderStatus;
+
+	private final Integer orderType;
+
+	private final Integer totalPrice;
+
+	private final Status status;
+
+	private final LocalDateTime statusUpdateTime;
+
+	private final Long addressId;
+
+	private final Long memberId;
+}

--- a/src/main/java/com/project/doubleshop/web/order/dto/OrderItemDto.java
+++ b/src/main/java/com/project/doubleshop/web/order/dto/OrderItemDto.java
@@ -8,9 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
-public class OrderDetailResult {
-	private Long orderId;
-
+public class OrderItemDto {
 	private Long itemId;
 
 	private String name;
@@ -20,4 +18,12 @@ public class OrderDetailResult {
 	private Integer stock;
 
 	private Integer quantity;
+
+	public OrderItemDto(OrderDetailResult source) {
+		this.itemId = source.getItemId();
+		this.name = source.getName();
+		this.price = source.getPrice();
+		this.stock = source.getStock();
+		this.quantity = source.getQuantity();
+	}
 }

--- a/src/main/java/com/project/doubleshop/web/order/dto/OrderStatusRequest.java
+++ b/src/main/java/com/project/doubleshop/web/order/dto/OrderStatusRequest.java
@@ -1,4 +1,4 @@
-package com.project.doubleshop.domain.order.entity;
+package com.project.doubleshop.web.order.dto;
 
 import java.time.LocalDateTime;
 
@@ -6,24 +6,20 @@ import com.project.doubleshop.domain.common.Status;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
-public class OrderDetail {
-	private Long orderId;
+public class OrderStatusRequest {
+	private Long id;
 
-	private Long itemId;
-
-	private Integer quantity;
-
-	private Integer price;
+	private Integer orderStatus;
 
 	private Status status;
 
 	private LocalDateTime statusUpdateTime;
+
+	private Long memberId;
 }

--- a/src/main/java/com/project/doubleshop/web/order/dto/OrderStatusRequest.java
+++ b/src/main/java/com/project/doubleshop/web/order/dto/OrderStatusRequest.java
@@ -17,8 +17,6 @@ public class OrderStatusRequest {
 
 	private Integer orderStatus;
 
-	private Status status;
-
 	private LocalDateTime statusUpdateTime;
 
 	private Long memberId;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # postgresql
-spring.datasource.url=jdbc:mysql://127.0.0.1:3306/doubleshop?characterEncoding=UTF8&amp;serverTimezone=Asia/Seoul
+spring.datasource.url=jdbc:mysql://127.0.0.1:3306/doubleshop?characterEncoding=UTF8&amp;serverTimezone=Asia/Seoul&amp;allowMultiQueries=true
 spring.datasource.username=dev
 spring.datasource.password=dev
 # mail

--- a/src/main/resources/mapper/addressMapper.xml
+++ b/src/main/resources/mapper/addressMapper.xml
@@ -1,12 +1,12 @@
 <!DOCTYPE mapper
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.project.doubleshop.domain.address.entity.Address">
+<mapper namespace="com.project.doubleshop.domain.address.mapper.AddressMapper">
     <insert id="insertAddress" parameterType="Address" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO ADDRESS (city, zipcode, detail, member_id)
         VALUES (#{city}, #{zipcode}, #{detail}, #{memberId})
     </insert>
-    <select id="selectByMemberId" resultType="Address" parameterType="long">
+    <select id="selectAddressByMemberId" resultType="Address" parameterType="long">
         SELECT id, city, zipcode, detail, member_id
         FROM ADDRESS WHERE member_id = #{memberId}
     </select>
@@ -14,7 +14,7 @@
         SELECT id, city, zipcode, detail, member_id
         FROM ADDRESS WHERE id = #{id}
     </select>
-    <update id="updateStatus">
+    <update id="updateAddressStatus">
         UPDATE ADDRESS SET
         status = #{statusCode},
         status_update_time = #{statusUpdateTime}

--- a/src/main/resources/mapper/addressMapper.xml
+++ b/src/main/resources/mapper/addressMapper.xml
@@ -1,0 +1,40 @@
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.project.doubleshop.domain.address.entity.Address">
+    <insert id="insertAddress" parameterType="Address" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO ADDRESS (city, zipcode, detail, member_id)
+        VALUES (#{city}, #{zipcode}, #{detail}, #{memberId})
+    </insert>
+    <select id="selectByMemberId" resultType="Address" parameterType="long">
+        SELECT id, city, zipcode, detail, member_id
+        FROM ADDRESS WHERE member_id = #{memberId}
+    </select>
+    <select id="selectAddressById" resultType="Address" parameterType="long">
+        SELECT id, city, zipcode, detail, member_id
+        FROM ADDRESS WHERE id = #{id}
+    </select>
+    <update id="updateStatus">
+        UPDATE ADDRESS SET
+        status = #{statusCode},
+        status_update_time = #{statusUpdateTime}
+        WHERE
+        <foreach item="id" index="index" collection="addressIds"
+                 open="id IN (" separator="," close=")">
+            #{id}
+        </foreach>
+    </update>
+    <update id="updateAddress" parameterType="Address">
+        UPDATE ADDRESS SET
+            city = #{city},
+            zipcode = #{zipcode},
+            detail = #{detail},
+            status = #{status},
+            status_update_time = #{statusUpdateTime},
+            member_id = #{memberId}
+        WHERE id = #{id}
+    </update>
+    <delete id="deleteAddress" parameterType="int">
+        DELETE FROM ADDRESS WHERE status = #{statusCode}
+    </delete>
+</mapper>

--- a/src/main/resources/mapper/itemMapper.xml
+++ b/src/main/resources/mapper/itemMapper.xml
@@ -68,4 +68,21 @@
     <delete id="deleteItem" parameterType="Status">
         DELETE FROM ITEM WHERE status = #{DELETED}
     </delete>
+    <select id="selectItemsInIds" resultType="Item">
+        SELECT id, name, description, brand_name, price, volume, dimension, package_type, origin, expiration, price_per_100g,
+        allergic_info, model_serial_no, rating, search_keyword, stock, discount_price, author, publisher, isbn, published_time,
+        is_oneday_eligible, is_fresh_eligible, status, status_update_time, category_id
+        FROM Item WHERE
+        <foreach item="id" index="index" collection="itemIds"
+                 open="id IN (" separator="," close=")">
+            #{id}
+        </foreach>
+    </select>
+    <update id="batchUpdateItems" parameterType="ItemStockQuery">
+        <foreach collection="queryList" item="item" index="index" open="" close="" separator=";">
+            UPDATE ITEM SET
+            stock = #{item.stock}
+            WHERE id = #{item.itemId}
+        </foreach>
+    </update>
 </mapper>

--- a/src/main/resources/mapper/orderDetailMapper.xml
+++ b/src/main/resources/mapper/orderDetailMapper.xml
@@ -6,16 +6,16 @@
         INSERT INTO ORDER_DETAIL (order_id, item_id, quantity, price)
         VALUES (#{orderId}, #{itemId}, #{quantity}, #{price})
     </insert>
-    <select id="selectByOrderId" parameterType="long" resultType="OrderDetail">
+    <select id="selectOrderDetailByOrderId" parameterType="long" resultType="OrderDetail">
         SELECT order_id, item_id, quantity, price
         FROM ORDER_DETAIL
         WHERE order_id = #{orderId}
     </select>
-    <select id="selectWithItemByOrderId" parameterType="long" resultType="OrderDetailResult">
+    <select id="selectOrderDetailWithItemByOrderId" parameterType="long" resultType="OrderDetailResult">
         SELECT order_id, i.id AS item_id, i.name, i.price, i.stock, quantity FROM ORDER_DETAIL
         JOIN ITEM i on item_id = i.id where order_id = #{orderId};
     </select>
-    <update id="updateStatus">
+    <update id="updateOrderDetailStatus">
         UPDATE ORDER_DETAIL SET
         status = #{statusCode},
         status_update_time = #{statusUpdateTime}

--- a/src/main/resources/mapper/orderDetailMapper.xml
+++ b/src/main/resources/mapper/orderDetailMapper.xml
@@ -28,4 +28,11 @@
     <delete id="deleteOrderDetails" parameterType="int">
         DELETE FROM ORDER_DETAIL WHERE status = #{statusCode}
     </delete>
+    <insert id="batchInsertOrderDetails" parameterType="OrderDetail">
+        INSERT INTO ORDER_DETAIL (order_id, item_id, quantity, price)
+        VALUES
+        <foreach collection="orderDetails" item="orderDetail" separator=",">
+            (#{orderId}, #{itemId}, #{quantity}, #{price})
+        </foreach>
+    </insert>
 </mapper>

--- a/src/main/resources/mapper/orderDetailMapper.xml
+++ b/src/main/resources/mapper/orderDetailMapper.xml
@@ -21,7 +21,7 @@
         status_update_time = #{statusUpdateTime}
         WHERE
         <foreach item="id" index="index" collection="orderIds"
-                 open="id IN (" separator="," close=")">
+                 open="order_id IN (" separator="," close=")">
             #{id}
         </foreach>
     </update>
@@ -32,7 +32,7 @@
         INSERT INTO ORDER_DETAIL (order_id, item_id, quantity, price)
         VALUES
         <foreach collection="orderDetails" item="orderDetail" separator=",">
-            (#{orderId}, #{itemId}, #{quantity}, #{price})
+            (#{orderDetail.orderId}, #{orderDetail.itemId}, #{orderDetail.quantity}, #{orderDetail.price})
         </foreach>
     </insert>
 </mapper>

--- a/src/main/resources/mapper/orderDetailMapper.xml
+++ b/src/main/resources/mapper/orderDetailMapper.xml
@@ -1,0 +1,31 @@
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.project.doubleshop.domain.order.mapper.OrderDetailMapper">
+    <insert id="insertOrderDetail" parameterType="OrderDetail">
+        INSERT INTO ORDER_DETAIL (order_id, item_id, quantity, price)
+        VALUES (#{orderId}, #{itemId}, #{quantity}, #{price})
+    </insert>
+    <select id="selectByOrderId" parameterType="long" resultType="OrderDetail">
+        SELECT order_id, item_id, quantity, price
+        FROM ORDER_DETAIL
+        WHERE order_id = #{orderId}
+    </select>
+    <select id="selectWithItemByOrderId" parameterType="long" resultType="OrderDetailResult">
+        SELECT order_id, i.id AS item_id, i.name, i.price, i.stock FROM ORDER_DETAIL
+        JOIN ITEM i on item_id = i.id where order_id = #{orderId};
+    </select>
+    <update id="updateStatus">
+        UPDATE ORDER_DETAIL SET
+        status = #{statusCode},
+        status_update_time = #{statusUpdateTime}
+        WHERE
+        <foreach item="id" index="index" collection="orderIds"
+                 open="id IN (" separator="," close=")">
+            #{id}
+        </foreach>
+    </update>
+    <delete id="deleteOrderDetails" parameterType="int">
+        DELETE FROM ORDER_DETAIL WHERE status = #{statusCode}
+    </delete>
+</mapper>

--- a/src/main/resources/mapper/orderDetailMapper.xml
+++ b/src/main/resources/mapper/orderDetailMapper.xml
@@ -12,7 +12,7 @@
         WHERE order_id = #{orderId}
     </select>
     <select id="selectWithItemByOrderId" parameterType="long" resultType="OrderDetailResult">
-        SELECT order_id, i.id AS item_id, i.name, i.price, i.stock FROM ORDER_DETAIL
+        SELECT order_id, i.id AS item_id, i.name, i.price, i.stock, quantity FROM ORDER_DETAIL
         JOIN ITEM i on item_id = i.id where order_id = #{orderId};
     </select>
     <update id="updateStatus">

--- a/src/main/resources/mapper/orderMapper.xml
+++ b/src/main/resources/mapper/orderMapper.xml
@@ -16,7 +16,7 @@
     <select id="selectOrderByIdAndMemberId" parameterType="long" resultType="Order">
         SELECT id, ordered_time, order_status, order_type, total_price,
                status, status_update_time, address_id, member_id
-        FROM `ORDER` WHERE id = #{id} AND member_id = #{member_id}
+        FROM `ORDER` WHERE id = #{id} AND member_id = #{memberId}
     </select>
     <select id="selectByMemberId" resultType="Order">
         SELECT id, ordered_time, order_status, order_type, total_price,
@@ -27,7 +27,7 @@
     <update id="updateOrderStatus" parameterType="OrderStatusRequest">
         UPDATE `ORDER` SET
             order_status = #{orderStatus},
-            status_updata_time = #{statusUpdataTime}
+            status_update_time = #{statusUpdateTime}
         WHERE id = #{id} AND member_id = #{memberId}
     </update>
     <update id="updateStatus">

--- a/src/main/resources/mapper/orderMapper.xml
+++ b/src/main/resources/mapper/orderMapper.xml
@@ -8,12 +8,12 @@
         VALUES (#{orderedTime}, #{orderStatus}, #{orderType}, #{totalPrice},
                 #{status}, #{statusUpdateTime}, #{addressId}, #{memberId});
     </insert>
-    <select id="selectByOrderId" parameterType="long" resultType="Order">
+    <select id="selectOrderByOrderId" parameterType="long" resultType="Order">
         SELECT id, ordered_time, order_status, order_type, total_price,
                 status, status_update_time, address_id, member_id
         FROM `ORDER` WHERE id = #{id}
     </select>
-    <select id="selectByIdAndMemberId" parameterType="long" resultType="Order">
+    <select id="selectOrderByIdAndMemberId" parameterType="long" resultType="Order">
         SELECT id, ordered_time, order_status, order_type, total_price,
                status, status_update_time, address_id, member_id
         FROM `ORDER` WHERE id = #{id} AND member_id = #{member_id}

--- a/src/main/resources/mapper/orderMapper.xml
+++ b/src/main/resources/mapper/orderMapper.xml
@@ -1,0 +1,42 @@
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.project.doubleshop.domain.order.mapper.OrderMapper">
+    <insert id="insertOrder" parameterType="Order" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO `ORDER` (ordered_time, order_status, order_type, total_price,
+                             status, status_update_time, address_id, member_id)
+        VALUES (#{orderedTime}, #{orderStatus}, #{orderType}, #{totalPrice},
+                #{status}, #{statusUpdateTime}, #{addressId}, #{memberId});
+    </insert>
+    <select id="selectByOrderId" parameterType="long" resultType="Order">
+        SELECT id, ordered_time, order_status, order_type, total_price,
+                status, status_update_time, address_id, member_id
+        FROM `ORDER` WHERE id = #{id}
+    </select>
+    <select id="selectByMemberId" resultType="Order">
+        SELECT id, ordered_time, order_status, order_type, total_price,
+                status, status_update_time, address_id, member_id
+        FROM `ORDER` WHERE member_id = #{memberId}
+        ORDER BY id DESC LIMIT #{size} OFFSET #{page}
+    </select>
+    <update id="updateOrderStatus" parameterType="OrderStatusRequest">
+        UPDATE `ORDER` SET
+            order_status = #{orderStatus}
+            status = #{status},
+            status_updata_time = #{statusUpdataTime}
+        WHERE id = #{id} AND member_id = #{memberId}
+    </update>
+    <update id="updateStatus">
+        UPDATE `ORDER` SET
+            status = #{statusCode},
+            status_update_time = #{statusUpdateTime}
+        WHERE
+        <foreach item="id" index="index" collection="orderIds"
+                 open="id IN (" separator="," close=")">
+            #{id}
+        </foreach>
+    </update>
+    <delete id="deleteOrders" parameterType="int">
+        DELETE FROM `ORDER` WHERE status = #{statusCode}
+    </delete>
+</mapper>

--- a/src/main/resources/mapper/orderMapper.xml
+++ b/src/main/resources/mapper/orderMapper.xml
@@ -13,6 +13,11 @@
                 status, status_update_time, address_id, member_id
         FROM `ORDER` WHERE id = #{id}
     </select>
+    <select id="selectByIdAndMemberId" parameterType="long" resultType="Order">
+        SELECT id, ordered_time, order_status, order_type, total_price,
+               status, status_update_time, address_id, member_id
+        FROM `ORDER` WHERE id = #{id} AND member_id = #{member_id}
+    </select>
     <select id="selectByMemberId" resultType="Order">
         SELECT id, ordered_time, order_status, order_type, total_price,
                 status, status_update_time, address_id, member_id
@@ -21,8 +26,7 @@
     </select>
     <update id="updateOrderStatus" parameterType="OrderStatusRequest">
         UPDATE `ORDER` SET
-            order_status = #{orderStatus}
-            status = #{status},
+            order_status = #{orderStatus},
             status_updata_time = #{statusUpdataTime}
         WHERE id = #{id} AND member_id = #{memberId}
     </update>

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -25,6 +25,7 @@
         <typeAlias type="com.project.doubleshop.domain.order.entity.OrderDetail" alias="OrderDetail"/>
         <typeAlias type="com.project.doubleshop.web.order.dto.OrderDetailResult" alias="OrderDetailResult"/>
         <typeAlias type="com.project.doubleshop.domain.address.entity.Address" alias="Address"/>
+        <typeAlias type="com.project.doubleshop.web.item.dto.ItemStockQuery" alias="ItemStockQuery"/>
     </typeAliases>
     <typeHandlers>
         <typeHandler handler="com.project.doubleshop.domain.common.StatusTypeHandler" />

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -20,6 +20,11 @@
         <typeAlias type="com.project.doubleshop.domain.delivery.entity.DeliveryDriver" alias="DeliveryDriver"/>
         <typeAlias type="com.project.doubleshop.domain.delivery.entity.DeliveryPolicy" alias="DeliveryPolicy"/>
         <typeAlias type="com.project.doubleshop.domain.cart.entity.Cart" alias="Cart"/>
+        <typeAlias type="com.project.doubleshop.domain.order.entity.Order" alias="Order"/>
+        <typeAlias type="com.project.doubleshop.web.order.dto.OrderStatusRequest" alias="OrderStatusRequest"/>
+        <typeAlias type="com.project.doubleshop.domain.order.entity.OrderDetail" alias="OrderDetail"/>
+        <typeAlias type="com.project.doubleshop.web.order.dto.OrderDetailResult" alias="OrderDetailResult"/>
+        <typeAlias type="com.project.doubleshop.domain.address.entity.Address" alias="Address"/>
     </typeAliases>
     <typeHandlers>
         <typeHandler handler="com.project.doubleshop.domain.common.StatusTypeHandler" />
@@ -35,5 +40,8 @@
         <mapper resource="mapper/deliveryDriverMapper.xml"/>
         <mapper resource="mapper/deliveryPolicyMapper.xml"/>
         <mapper resource="mapper/cartMapper.xml"/>
+        <mapper resource="mapper/orderMapper.xml"/>
+        <mapper resource="mapper/orderDetailMapper.xml"/>
+        <mapper resource="mapper/addressMapper.xml"/>
     </mappers>
 </configuration>

--- a/src/test/java/com/project/doubleshop/domain/address/mapper/MockAddress.java
+++ b/src/test/java/com/project/doubleshop/domain/address/mapper/MockAddress.java
@@ -1,0 +1,44 @@
+package com.project.doubleshop.domain.address.mapper;
+
+import java.time.LocalDateTime;
+
+import com.project.doubleshop.domain.address.entity.Address;
+import com.project.doubleshop.domain.common.Status;
+import com.project.doubleshop.domain.member.service.MockMember;
+
+public class MockAddress {
+	public static class Address1 {
+		public static final Long ID = 1L;
+
+		public static final String CITY = "서울";
+
+		public static final String ZIPCODE = "012345";
+
+		public static final String DETAIL = "어딘가에 있는 아파트";
+
+		public static final Status STATUS = Status.ACTIVATED;
+
+		public static final LocalDateTime STATUS_UPDATE_TIME = LocalDateTime.of(2021, 10, 13, 9, 27, 1);
+
+		public static final Long MEMBER_ID = MockMember.Member1.ID;
+
+		public static final Address ADDRESS_1 = Address.builder()
+			.id(ID)
+			.city(CITY)
+			.zipcode(ZIPCODE)
+			.detail(DETAIL)
+			.status(STATUS)
+			.statusUpdateTime(STATUS_UPDATE_TIME)
+			.memberId(MEMBER_ID)
+			.build();
+
+		public static final Address ADDRESS_1_FORM = Address.builder()
+			.city(CITY)
+			.zipcode(ZIPCODE)
+			.detail(DETAIL)
+			.status(STATUS)
+			.statusUpdateTime(STATUS_UPDATE_TIME)
+			.memberId(MEMBER_ID)
+			.build();
+	}
+}

--- a/src/test/java/com/project/doubleshop/domain/item/MockItem.java
+++ b/src/test/java/com/project/doubleshop/domain/item/MockItem.java
@@ -1,0 +1,54 @@
+package com.project.doubleshop.domain.item;
+
+import com.project.doubleshop.domain.item.entity.Item;
+import com.project.doubleshop.web.item.dto.ItemForm;
+
+public class MockItem {
+	public static class Item1 {
+		public static final Long ID = 1L;
+		public static final String NAME = "상품이름";
+		public static final String DESCRIPTION = "상품설명";
+		public static final String BRAND_NAME = "브랜드 명";
+		public static final Integer PRICE = 1300;
+		public static final String PACKAGE_TYPE = "비닐포장";
+		public static final String ORIGIN = "국내산";
+		public static final String MODEL_SERIAL_NO = "1835265762 - 3121080524";
+		public static final String SEARCH_KEYWORD = "가성비 검색어";
+		public static final Integer STOCK = 365;
+		public static final Boolean IS_ONEDAY_ELIGIBLE = true;
+		public static final Long CATEGORY_ID = 1L;
+
+		public static final Item ITEM = Item.builder()
+			.id(ID)
+			.name(NAME)
+			.description(DESCRIPTION)
+			.brandName(BRAND_NAME)
+			.price(PRICE)
+			.packageType(PACKAGE_TYPE)
+			.origin(ORIGIN)
+			.modelSerialNo(MODEL_SERIAL_NO)
+			.searchKeyword(SEARCH_KEYWORD)
+			.stock(STOCK)
+			.isOnedayEligible(IS_ONEDAY_ELIGIBLE)
+			.categoryId(CATEGORY_ID)
+			.build();
+
+		public static final Item NEW_ITEM = Item.builder()
+			.name(NAME)
+			.description(DESCRIPTION)
+			.brandName(BRAND_NAME)
+			.price(PRICE)
+			.packageType(PACKAGE_TYPE)
+			.origin(ORIGIN)
+			.modelSerialNo(MODEL_SERIAL_NO)
+			.searchKeyword(SEARCH_KEYWORD)
+			.stock(STOCK)
+			.isOnedayEligible(IS_ONEDAY_ELIGIBLE)
+			.categoryId(CATEGORY_ID)
+			.build();
+
+		public static final ItemForm ITEM_FORM_NEW = new ItemForm(NEW_ITEM);
+
+		public static final ItemForm ITEM_FORM_UPDATE = new ItemForm(ITEM);
+	}
+}

--- a/src/test/java/com/project/doubleshop/domain/member/service/MockMember.java
+++ b/src/test/java/com/project/doubleshop/domain/member/service/MockMember.java
@@ -28,4 +28,75 @@ public class MockMember {
 			.build();
 	}
 
+	public static class Member2 {
+		public static final Long ID = 2L;
+		public static final String USER_ID = "wanni1028";
+		public static final String PASSWORD = "$2a$12$wctB9qCE5y.r8qob/SPQMOpQaLT6ZGzMLcY1bM6j0JUonPMGr2H9e";
+		public static final String NAME = "wanni";
+		public static final String EMAIL = "wanni1028@gmail.com";
+		public static final String PHONE = "010-1234-5678";
+		public static final LocalDateTime STATUS_UPDATE_TIME = LocalDateTime.of(2022, 1, 6, 12, 32, 10);
+		public static final LocalDateTime CREATE_TIME = LocalDateTime.of(2022, 1, 6, 12, 32, 10);
+
+		public static final Member MEMBER = Member.builder()
+			.id(ID)
+			.userId(USER_ID)
+			.password(PASSWORD)
+			.name(NAME)
+			.email(EMAIL)
+			.phone(PHONE)
+			.status(Status.ACTIVATED)
+			.statusUpdateTime(STATUS_UPDATE_TIME)
+			.createTime(CREATE_TIME)
+			.count(0)
+			.build();
+	}
+
+	public static class Member3 {
+		public static final Long ID = 3L;
+		public static final String USER_ID = "czwe1028";
+		public static final String PASSWORD = "$2a$12$wctB9qCE5y.r8qob/SPQMOpQaLT6ZGzMLcY1bM6j0JUonPMGr2H9e";
+		public static final String NAME = "czwe";
+		public static final String EMAIL = "czwe1028@gmail.com";
+		public static final String PHONE = "010-1234-5678";
+		public static final LocalDateTime STATUS_UPDATE_TIME = LocalDateTime.of(2022, 1, 6, 12, 32, 10);
+		public static final LocalDateTime CREATE_TIME = LocalDateTime.of(2022, 1, 6, 12, 32, 10);
+
+		public static final Member MEMBER = Member.builder()
+			.id(ID)
+			.userId(USER_ID)
+			.password(PASSWORD)
+			.name(NAME)
+			.email(EMAIL)
+			.phone(PHONE)
+			.status(Status.ACTIVATED)
+			.statusUpdateTime(STATUS_UPDATE_TIME)
+			.createTime(CREATE_TIME)
+			.count(0)
+			.build();
+	}
+
+	public static class Member4 {
+		public static final Long ID = 4L;
+		public static final String USER_ID = "aasw1028";
+		public static final String PASSWORD = "$2a$12$wctB9qCE5y.r8qob/SPQMOpQaLT6ZGzMLcY1bM6j0JUonPMGr2H9e";
+		public static final String NAME = "aasw";
+		public static final String EMAIL = "aasw1028@gmail.com";
+		public static final String PHONE = "010-1234-5678";
+		public static final LocalDateTime STATUS_UPDATE_TIME = LocalDateTime.of(2022, 1, 6, 12, 32, 10);
+		public static final LocalDateTime CREATE_TIME = LocalDateTime.of(2022, 1, 6, 12, 32, 10);
+
+		public static final Member MEMBER = Member.builder()
+			.id(ID)
+			.userId(USER_ID)
+			.password(PASSWORD)
+			.name(NAME)
+			.email(EMAIL)
+			.phone(PHONE)
+			.status(Status.ACTIVATED)
+			.statusUpdateTime(STATUS_UPDATE_TIME)
+			.createTime(CREATE_TIME)
+			.count(0)
+			.build();
+	}
 }

--- a/src/test/java/com/project/doubleshop/domain/order/MockOrder.java
+++ b/src/test/java/com/project/doubleshop/domain/order/MockOrder.java
@@ -1,0 +1,97 @@
+package com.project.doubleshop.domain.order;
+
+import java.time.LocalDateTime;
+
+import com.project.doubleshop.domain.common.Status;
+import com.project.doubleshop.domain.member.service.MockMember;
+import com.project.doubleshop.domain.order.entity.Order;
+
+public class MockOrder {
+	public static class Order1 {
+		public static final Long ID = 1L;
+
+		public static final Long MEMBER_ID = MockMember.Member1.ID;
+
+		public static final LocalDateTime ORDERED_TIME = LocalDateTime.of(2022, 1, 6, 12, 32, 10);
+
+		public static final Status STATUS = Status.ACTIVATED;
+
+		public static final LocalDateTime STATUS_UPDATE_TIME = LocalDateTime.of(2022, 1, 6, 12, 32, 10);
+
+		public static final LocalDateTime CREATE_TIME = LocalDateTime.of(2022, 1, 6, 12, 32, 10);
+
+		public static final Order ORDER = Order.builder()
+			.id(ID)
+			.memberId(MEMBER_ID)
+			.orderedTime(ORDERED_TIME)
+			.status(STATUS)
+			.statusUpdateTime(STATUS_UPDATE_TIME)
+			.build();
+	}
+
+	public static class Order2 {
+		public static final Long ID = 2L;
+
+		public static final Long MEMBER_ID = MockMember.Member2.ID;
+
+		public static final LocalDateTime ORDERED_TIME = LocalDateTime.of(2022, 1, 6, 12, 32, 10);
+
+		public static final Status STATUS = Status.ACTIVATED;
+
+		public static final LocalDateTime STATUS_UPDATE_TIME = LocalDateTime.of(2022, 1, 6, 12, 32, 10);
+
+		public static final LocalDateTime CREATE_TIME = LocalDateTime.of(2022, 1, 6, 12, 32, 10);
+
+		public static final Order ORDER = Order.builder()
+			.id(ID)
+			.memberId(MEMBER_ID)
+			.orderedTime(ORDERED_TIME)
+			.status(STATUS)
+			.statusUpdateTime(STATUS_UPDATE_TIME)
+			.build();
+	}
+
+	public static class Order3 {
+		public static final Long ID = 3L;
+
+		public static final Long MEMBER_ID = MockMember.Member3.ID;
+
+		public static final LocalDateTime ORDERED_TIME = LocalDateTime.of(2022, 1, 6, 12, 32, 10);
+
+		public static final Status STATUS = Status.ACTIVATED;
+
+		public static final LocalDateTime STATUS_UPDATE_TIME = LocalDateTime.of(2022, 1, 6, 12, 32, 10);
+
+		public static final LocalDateTime CREATE_TIME = LocalDateTime.of(2022, 1, 6, 12, 32, 10);
+
+		public static final Order ORDER = Order.builder()
+			.id(ID)
+			.memberId(MEMBER_ID)
+			.orderedTime(ORDERED_TIME)
+			.status(STATUS)
+			.statusUpdateTime(STATUS_UPDATE_TIME)
+			.build();
+	}
+
+	public static class Order4 {
+		public static final Long ID = 4L;
+
+		public static final Long MEMBER_ID = MockMember.Member4.ID;
+
+		public static final LocalDateTime ORDERED_TIME = LocalDateTime.of(2022, 1, 6, 12, 32, 10);
+
+		public static final Status STATUS = Status.ACTIVATED;
+
+		public static final LocalDateTime STATUS_UPDATE_TIME = LocalDateTime.of(2022, 1, 6, 12, 32, 10);
+
+		public static final LocalDateTime CREATE_TIME = LocalDateTime.of(2022, 1, 6, 12, 32, 10);
+
+		public static final Order ORDER = Order.builder()
+			.id(ID)
+			.memberId(MEMBER_ID)
+			.orderedTime(ORDERED_TIME)
+			.status(STATUS)
+			.statusUpdateTime(STATUS_UPDATE_TIME)
+			.build();
+	}
+}

--- a/src/test/java/com/project/doubleshop/domain/order/MockOrderDetail.java
+++ b/src/test/java/com/project/doubleshop/domain/order/MockOrderDetail.java
@@ -1,0 +1,27 @@
+package com.project.doubleshop.domain.order;
+
+import java.time.LocalDateTime;
+
+import com.project.doubleshop.domain.common.Status;
+import com.project.doubleshop.domain.order.entity.Order;
+import com.project.doubleshop.domain.order.entity.OrderDetail;
+
+public class MockOrderDetail {
+	public static class OrderDetail1 {
+		public static final Long ORDER_ID = MockOrder.Order1.ID;
+		public static final Long ITEM_ID = 1L;
+		public static final Integer QUANTITY = 1;
+		public static final Integer PRICE = 1000;
+		public static final Status STATUS = Status.ACTIVATED;
+		public static final LocalDateTime STATUS_UPDATE_TIME = LocalDateTime.of(2022, 1, 6, 12, 32, 10);
+
+		public static final OrderDetail ORDER_DETAIL = OrderDetail.builder()
+			.orderId(ORDER_ID)
+			.itemId(ITEM_ID)
+			.quantity(QUANTITY)
+			.price(PRICE)
+			.status(STATUS)
+			.statusUpdateTime(STATUS_UPDATE_TIME)
+			.build();
+	}
+}

--- a/src/test/java/com/project/doubleshop/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/project/doubleshop/domain/order/service/OrderServiceTest.java
@@ -1,0 +1,107 @@
+package com.project.doubleshop.domain.order.service;
+
+import static com.project.doubleshop.domain.item.MockItem.*;
+import static com.project.doubleshop.domain.member.service.MockMember.*;
+import static com.project.doubleshop.domain.order.MockOrder.*;
+import static com.project.doubleshop.domain.order.MockOrderDetail.*;
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.project.doubleshop.domain.cart.entity.Cart;
+import com.project.doubleshop.domain.cart.service.CartService;
+import com.project.doubleshop.domain.cart.service.MockCart;
+import com.project.doubleshop.domain.item.MockItem;
+import com.project.doubleshop.domain.item.entity.Item;
+import com.project.doubleshop.domain.item.service.ItemService;
+import com.project.doubleshop.domain.member.service.MockMember;
+import com.project.doubleshop.domain.order.MockOrder;
+import com.project.doubleshop.domain.order.MockOrderDetail;
+import com.project.doubleshop.domain.order.entity.Order;
+import com.project.doubleshop.domain.order.entity.OrderDetail;
+import com.project.doubleshop.domain.order.repository.OrderDetailRepository;
+import com.project.doubleshop.domain.order.repository.OrderRepository;
+import com.project.doubleshop.web.config.support.Pageable;
+import com.project.doubleshop.web.config.support.SimplePageRequest;
+import com.project.doubleshop.web.order.dto.OrderDetailDto;
+import com.project.doubleshop.web.order.dto.OrderDetailResult;
+import com.project.doubleshop.web.order.dto.OrderStatusRequest;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+	@Mock
+	OrderDetailRepository orderDetailRepository;
+
+	@Mock
+	OrderRepository orderRepository;
+
+	@Mock
+	CartService cartService;
+
+	@Mock
+	ItemService itemService;
+
+	@InjectMocks
+	OrderService orderService;
+
+	@Test
+	void createOrder() {
+		List<Long> itemIds = List.of(Item1.ID);
+		Order order = Order1.ORDER;
+		List<Item> items = List.of(Item1.ITEM);
+		List<Cart> carts = List.of(MockCart.Cart1.CART);
+
+		given(cartService.findCartsByMemberId(Member1.ID)).willReturn(carts);
+		given(itemService.findItemsInItemIds(itemIds)).willReturn(items);
+		given(orderRepository.save(order)).willReturn(true);
+		given(orderDetailRepository.batchInsert(anyList())).willReturn(1);
+
+		Order result = orderService.createOrder(Member1.ID, order);
+
+		assertThat(result.getId()).isEqualTo(order.getId());
+	}
+
+	@Test
+	void cancelOrder() {
+		OrderDetailResult orderDetailResult = new OrderDetailResult(Order1.ID, Item1.ID, Item1.NAME, Item1.PRICE,
+			Item1.STOCK, OrderDetail1.QUANTITY);
+
+		given(orderRepository.findByIdAndMemberId(Order1.ID, Order1.MEMBER_ID)).willReturn(Order1.ORDER);
+		given(orderDetailRepository.findWithItemByOrderId(Order1.ID)).willReturn(List.of(orderDetailResult));
+		given(itemService.findItemsInItemIds(List.of(Item1.ID))).willReturn(List.of(Item1.ITEM));
+		given(orderRepository.updateOrderStatus(any(OrderStatusRequest.class))).willReturn(1);
+
+		Order order = orderService.cancelOrder(Order1.ID, Order1.MEMBER_ID);
+
+		assertThat(order.getId()).isEqualTo(Order1.ID);
+	}
+
+	@Test
+	void findOrderByMemberId() {
+		Pageable pageable = new SimplePageRequest();
+
+		given(orderRepository.findByMemberId(Member1.ID, pageable)).willReturn(List.of(Order1.ORDER));
+
+		List<Order> orders = orderService.findOrderByMemberId(Member1.ID, pageable);
+
+		assertThat(orders.size()).isEqualTo(1);
+	}
+
+	@Test
+	void findOrderDetail() {
+		given(orderDetailRepository.findWithItemByOrderId(Order1.ID)).willReturn(anyList());
+
+		OrderDetailDto orderDetail = orderService.findOrderDetail(Order1.MEMBER_ID, Order1.ID);
+
+		assertThat(orderDetail).isNotNull();
+	}
+}


### PR DESCRIPTION
# Road Map
![order](https://user-images.githubusercontent.com/81374655/150825292-8cd24f76-f064-4520-a4bc-3349d8dd4f6b.png)

# Overview
- 사용자(소비자)의 '주문하기', '주문내역 조회', '주문내역 상세 조회' '주문취소' 요청에 해당하는 기능의 트랜잭션을 설계하고 구현하였습니다.
- 사용자가 '관리자' 였을 때의 유즈케이스를 만족하는 api 기능은 아직 구현하지 않았습니다.

# Description
- 주문하기 (**POST** / `api/member/{memberId}/order`)
- 주문 목록 조회 (**GET** `api/member/{memberId}/order`)
- 주문 단건 상세 조회 (**GET** `api/member/{memberId}/order/{orderId}`)
- 주문 취소(삭제 x) (**DELETE** `api/member/{memberId}/order/{orderId}`)