### PR TITLE
이미지 업로드 방식 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,8 @@ build/
 .vscode/
 
 ### application profile ###
-src/main/resources/application-dev.properties
-src/main/resources/application-local.properties
-src/main/resources/application-prod.properties
-src/main/resources/application-test.properties
+**/resources/application-dev.properties
+**/resources/application-local.properties
+**/resources/application-prod.properties
+**/resources/application-test.properties
 bin/

--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,8 @@ build/
 .vscode/
 
 ### application profile ###
-**/application-local.properties
+src/main/resources/application-dev.yml
+src/main/resources/application-local.yml
+src/main/resources/application-prod.yml
+src/main/resources/application-test.yml
 bin/

--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,8 @@ build/
 .vscode/
 
 ### application profile ###
-src/main/resources/application-dev.yml
-src/main/resources/application-local.yml
-src/main/resources/application-prod.yml
-src/main/resources/application-test.yml
+src/main/resources/application-dev.properties
+src/main/resources/application-local.properties
+src/main/resources/application-prod.properties
+src/main/resources/application-test.properties
 bin/

--- a/src/main/java/com/project/doubleshop/domain/item/entity/Item.java
+++ b/src/main/java/com/project/doubleshop/domain/item/entity/Item.java
@@ -109,6 +109,9 @@ public class Item implements StatusManager {
     // ISBN
     private String isbn;
 
+    // 이미지 url
+    private String imageUrl;
+
     // 발행일
     @PastOrPresent(message = "field 'publishedTime' must be present or past")
     private LocalDate publishedTime;
@@ -142,6 +145,10 @@ public class Item implements StatusManager {
 
     public void setCategory(Category category) {
         this.category = category;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
     }
 
     public void decreaseStock(int stock) {

--- a/src/main/java/com/project/doubleshop/domain/item/service/ItemService.java
+++ b/src/main/java/com/project/doubleshop/domain/item/service/ItemService.java
@@ -29,9 +29,19 @@ public class ItemService {
 
 	@Transactional
 	public Item save(ItemForm itemForm) {
+		return save(itemForm, null);
+	}
+
+	@Transactional
+	public Item save(ItemForm itemForm, String imageUrl) {
 		Category category = categoryService.findById(itemForm.getCategoryId());
 		Item item = Item.convertToItem(itemForm);
 		item.setCategory(category);
+
+		if (imageUrl != null) {
+			item.setImageUrl(imageUrl);
+		}
+
 		return itemRepository.save(item);
 	}
 

--- a/src/main/java/com/project/doubleshop/web/common/file/ImageFile.java
+++ b/src/main/java/com/project/doubleshop/web/common/file/ImageFile.java
@@ -49,7 +49,8 @@ public class ImageFile {
 	}
 
 	public String extension(String defaultExtension) {
-		return hasLength(defaultExtension) ? getExtension(originalFileName) : defaultExtension;
+		String extension = getExtension(originalFileName);
+		return hasLength(extension) ? extension : defaultExtension;
 	}
 
 	public String randomName(String defaultExtension) {

--- a/src/main/java/com/project/doubleshop/web/common/file/ImageFile.java
+++ b/src/main/java/com/project/doubleshop/web/common/file/ImageFile.java
@@ -61,17 +61,18 @@ public class ImageFile {
 		return name + "." + extension(defaultExtension);
 	}
 
-	public static void uploadImageFile(FileClient fileClient, ImageFile file, String path) {
+	public static String uploadImageFile(FileClient fileClient, ImageFile file, String path) {
 		log.info("upload image file");
 
 		if (file != null) {
 			String key = file.randomName(path, "jpeg");
 			try {
-				fileClient.upload(file.inputStream(), file.length(), key, file.getContentType(), null);
+				return fileClient.upload(file.inputStream(), file.length(), key, file.getContentType(), null);
 			} catch (AmazonS3Exception e) {
 				log.warn("Amazon S3 error (key: {}): {}", key, e.getMessage(), e);
 			}
 		}
+		return null;
 	}
 
 	public InputStream inputStream() {

--- a/src/main/java/com/project/doubleshop/web/common/file/client/AwsS3Client.java
+++ b/src/main/java/com/project/doubleshop/web/common/file/client/AwsS3Client.java
@@ -90,8 +90,8 @@ public class AwsS3Client extends DefaultFileClient {
 
 	private String executePut(PutObjectRequest request) {
 		amazonS3.putObject(request.withCannedAcl(CannedAccessControlList.PublicRead));
-		String result = url + request.getKey();
-		log.info("utl {} created.", result);
+		String result = request.getKey();
+		log.debug("s3 object key {} created.", result);
 		return result;
 	}
 

--- a/src/main/java/com/project/doubleshop/web/common/file/client/AwsS3Client.java
+++ b/src/main/java/com/project/doubleshop/web/common/file/client/AwsS3Client.java
@@ -25,8 +25,10 @@ import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
-@Profile("prod")
+@Profile("local")
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AwsS3Client extends DefaultFileClient {
@@ -88,10 +90,9 @@ public class AwsS3Client extends DefaultFileClient {
 
 	private String executePut(PutObjectRequest request) {
 		amazonS3.putObject(request.withCannedAcl(CannedAccessControlList.PublicRead));
-		if (!url.endsWith("/")) {
-			url = "/" + url + "/" + request.getKey();
-		}
-		return url;
+		String result = url + request.getKey();
+		log.info("utl {} created.", result);
+		return result;
 	}
 
 	private void executeDelete(DeleteObjectRequest request) {

--- a/src/main/java/com/project/doubleshop/web/common/file/client/DefaultFileClient.java
+++ b/src/main/java/com/project/doubleshop/web/common/file/client/DefaultFileClient.java
@@ -16,7 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
 
-@Profile("local")
+@Profile("back")
 @Component
 @RequiredArgsConstructor
 public class DefaultFileClient implements FileClient {

--- a/src/main/java/com/project/doubleshop/web/item/controller/api/ItemRestController.java
+++ b/src/main/java/com/project/doubleshop/web/item/controller/api/ItemRestController.java
@@ -44,17 +44,17 @@ public class ItemRestController {
 
 	@PostMapping(value = "member/{memberId}/item", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
 	public ResponseEntity<ItemApiResult> newItem(@RequestPart ItemForm itemForm, @RequestPart(required = false)
-		MultipartFile[] imageFiles) {
+		MultipartFile imageFile) {
 		Item item = itemService.save(itemForm);
 		URI location = ServletUriComponentsBuilder
 			.fromCurrentRequest()
 			.build()
 			.toUri();
 
-		String path = location.getPath() + "/" + item.getId();
-
-		if (imageFiles != null) {
-			Arrays.asList(imageFiles).forEach(file -> uploadImageFile(fileClient, of(file), path));
+		String imageUrl = uploadImageFile(fileClient, of(imageFile), null);
+		
+		if (imageUrl != null) {
+			item.setImageUrl(imageUrl);
 		}
 
 		return ResponseEntity.created(location).body(new ItemApiResult(item));

--- a/src/main/java/com/project/doubleshop/web/item/controller/api/ItemRestController.java
+++ b/src/main/java/com/project/doubleshop/web/item/controller/api/ItemRestController.java
@@ -45,17 +45,14 @@ public class ItemRestController {
 	@PostMapping(value = "member/{memberId}/item", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
 	public ResponseEntity<ItemApiResult> newItem(@RequestPart ItemForm itemForm, @RequestPart(required = false)
 		MultipartFile imageFile) {
-		Item item = itemService.save(itemForm);
 		URI location = ServletUriComponentsBuilder
 			.fromCurrentRequest()
 			.build()
 			.toUri();
 
 		String imageUrl = uploadImageFile(fileClient, of(imageFile), null);
-		
-		if (imageUrl != null) {
-			item.setImageUrl(imageUrl);
-		}
+
+		Item item = itemService.save(itemForm, imageUrl);
 
 		return ResponseEntity.created(location).body(new ItemApiResult(item));
 	}

--- a/src/main/java/com/project/doubleshop/web/item/dto/ItemForm.java
+++ b/src/main/java/com/project/doubleshop/web/item/dto/ItemForm.java
@@ -76,6 +76,8 @@ public class ItemForm {
 	// ISBN
 	private String isbn;
 
+	private String imageUrl;
+
 	// 발행일
 	private LocalDate publishedTime;
 
@@ -106,6 +108,7 @@ public class ItemForm {
 		this.author = source.getAuthor();
 		this.publisher = source.getPublisher();
 		this.isbn = source.getIsbn();
+		this.imageUrl = source.getImageUrl();
 		this.publishedTime = source.getPublishedTime();
 		this.isOnedayEligible = source.getIsOnedayEligible();
 		this.isFreshEligible = source.getIsFreshEligible();

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,24 @@
+# SQL
+mysql-datasource=jdbc:mysql://127.0.0.1:3306/doubleshop?characterEncoding=UTF8&serverTimezone=Asia/Seoul&allowMultiQueries=true
+mysql-username=dev
+mysql-password=dev
+# azure
+azure.keyvault.client-id=501df022-3551-480f-8139-e70294ce79e2
+azure.keyvault.enabled=true
+azure.keyvault.tenant-id=04608e41-ef04-4ef8-9210-1d20c6bb0ce5
+azure.keyvault.uri=https://doubleshop.vault.azure.net/
+azure.keyvault.secret-keys=s3-access-key, s3-secrete-key
+# JPAupdate
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+spring.jpa.properties.hibernate.format_sql=true
+logging.level.org.hibernate.SQL=debug
+logging.level.org.hibernate.type.descriptor.sql=trace
+# redis
+redis-session-host=localhost
+# admin-key
+admin-key=admin
+# s3
+s3-region=ap-northeast-2
+s3-url=https://s3.ap-northeast-2.amazonaws.com
+s3-bucketName=doubleshop

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -20,5 +20,5 @@ redis-session-host=localhost
 admin-key=admin
 # s3
 s3-region=ap-northeast-2
-s3-url=https://s3.ap-northeast-2.amazonaws.com
-s3-bucketName=doubleshop
+s3-url=https://wanni-bucket.s3.ap-northeast-2.amazonaws.com/
+s3-bucketName=wanni-bucket


### PR DESCRIPTION
- 기존에는 상품 페이지에 사용되는 이미지를 업로드 할때, 용도(섬네일, 상세 페이지 이미지)에 따라 putObject를 여러번 호출하는 것은 비효율적이라고 판단.
- 또한 원본의 용량이 큰 이미지를 여러번 저장하는 것보다, 필요한 이미지를 압축하여, 함께 저장하는 것이 read/write의 효율 그리고, aws 비용도 절약할 수 있다.
- 그래서 aws lambda를 활용하여, 하나의 이미지로 용도에 따라 다양한 크기의 이미지를 S3에 저장할 수 있게 하였다.