### PR TITLE
Feat: 상품추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,4 @@ build/
 .vscode/
 
 ### application profile ###
-**/resources/application-dev.properties
 **/resources/application-local.properties
-**/resources/application-prod.properties
-**/resources/application-test.properties
-bin/

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,15 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
+            <version>2.10.9.2</version>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/src/main/java/com/project/doubleshop/domain/category/service/CategoryService.java
+++ b/src/main/java/com/project/doubleshop/domain/category/service/CategoryService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +27,7 @@ public class CategoryService {
 		return categoryRepository.save(category);
 	}
 
+	@Cacheable(value = "category", key = "{#categoryId}")
 	public Category findById(Long categoryId) {
 		return categoryRepository.findById(categoryId)
 			.orElseThrow(() -> new NotFoundException(String.format("Category ID '%s' not found.", categoryId)));

--- a/src/main/java/com/project/doubleshop/domain/common/CategoryManager.java
+++ b/src/main/java/com/project/doubleshop/domain/common/CategoryManager.java
@@ -1,0 +1,36 @@
+package com.project.doubleshop.domain.common;
+
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Component;
+
+import com.project.doubleshop.domain.category.entity.Category;
+import com.project.doubleshop.domain.category.service.CategoryService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CategoryManager {
+
+	private final CategoryService categoryService;
+
+	private final CacheManager cacheManager;
+
+	@PostConstruct
+	private void warmUp() {
+		List<Category> categories = categoryService.findAll();
+		Cache categoryCache = cacheManager.getCache("category");
+		categories.forEach(c -> {
+			assert categoryCache != null;
+			categoryCache.put(c.getId(), c);
+		});
+		log.info("cache category");
+	}
+}

--- a/src/main/java/com/project/doubleshop/domain/common/config/CacheConfig.java
+++ b/src/main/java/com/project/doubleshop/domain/common/config/CacheConfig.java
@@ -1,0 +1,39 @@
+package com.project.doubleshop.domain.common.config;
+
+import java.util.Objects;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.ehcache.EhCacheCacheManager;
+import org.springframework.cache.ehcache.EhCacheManagerFactoryBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.config.CacheConfiguration;
+import net.sf.ehcache.config.MemoryUnit;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+	@Bean
+	public EhCacheManagerFactoryBean cacheManagerFactoryBean() {
+		return new EhCacheManagerFactoryBean();
+	}
+
+	@Bean
+	public CacheManager ehCacheCacheManager() {
+		CacheConfiguration oEmbedCacheConfig = new CacheConfiguration()
+			.eternal(true)
+			.maxEntriesLocalHeap(100)
+			.memoryStoreEvictionPolicy("LRU")
+			.name("category");
+
+		Cache categoryCache = new Cache(oEmbedCacheConfig);
+		net.sf.ehcache.CacheManager cacheManager
+			= Objects.requireNonNull(cacheManagerFactoryBean().getObject());
+
+		cacheManager.addCache(categoryCache);
+		return new EhCacheCacheManager(cacheManager);
+	}
+}

--- a/src/main/java/com/project/doubleshop/domain/item/entity/Item.java
+++ b/src/main/java/com/project/doubleshop/domain/item/entity/Item.java
@@ -2,9 +2,7 @@ package com.project.doubleshop.domain.item.entity;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
@@ -110,7 +108,7 @@ public class Item implements StatusManager {
     private String isbn;
 
     // 이미지 url
-    private String imageUrl;
+    private String imageUri;
 
     // 발행일
     @PastOrPresent(message = "field 'publishedTime' must be present or past")
@@ -147,8 +145,8 @@ public class Item implements StatusManager {
         this.category = category;
     }
 
-    public void setImageUrl(String imageUrl) {
-        this.imageUrl = imageUrl;
+    public void setImageUri(String imageUrl) {
+        this.imageUri = imageUrl;
     }
 
     public void decreaseStock(int stock) {

--- a/src/main/java/com/project/doubleshop/domain/item/service/ItemService.java
+++ b/src/main/java/com/project/doubleshop/domain/item/service/ItemService.java
@@ -1,8 +1,6 @@
 package com.project.doubleshop.domain.item.service;
 
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -14,7 +12,6 @@ import com.project.doubleshop.domain.common.Status;
 import com.project.doubleshop.domain.exception.NotFoundException;
 import com.project.doubleshop.domain.item.entity.Item;
 import com.project.doubleshop.domain.item.repository.ItemRepository;
-import com.project.doubleshop.domain.utils.ExceptionUtils;
 import com.project.doubleshop.web.item.dto.ItemForm;
 
 import lombok.RequiredArgsConstructor;
@@ -39,7 +36,7 @@ public class ItemService {
 		item.setCategory(category);
 
 		if (imageUrl != null) {
-			item.setImageUrl(imageUrl);
+			item.setImageUri(imageUrl);
 		}
 
 		return itemRepository.save(item);

--- a/src/main/java/com/project/doubleshop/web/config/security/WebSecurityConfigurer.java
+++ b/src/main/java/com/project/doubleshop/web/config/security/WebSecurityConfigurer.java
@@ -107,6 +107,7 @@ public class WebSecurityConfigurer extends WebSecurityConfigurerAdapter {
 				.antMatchers("/api/member/join").permitAll()
 				.antMatchers("/api/member/exists/**").permitAll()
 				.antMatchers("/api/member/*/item").hasRole(Role.ADMIN.name())
+				.antMatchers("/api/member/*/category").hasRole(Role.ADMIN.name())
 				.antMatchers("/api/member/**").hasRole(Role.USER.name())
 				.accessDecisionManager(accessDecisionManager())
 				.anyRequest().permitAll()

--- a/src/main/java/com/project/doubleshop/web/item/dto/ItemForm.java
+++ b/src/main/java/com/project/doubleshop/web/item/dto/ItemForm.java
@@ -2,8 +2,6 @@ package com.project.doubleshop.web.item.dto;
 
 import java.time.LocalDate;
 
-import com.project.doubleshop.domain.category.entity.Category;
-import com.project.doubleshop.domain.common.Status;
 import com.project.doubleshop.domain.item.entity.Item;
 
 import lombok.AccessLevel;
@@ -108,7 +106,7 @@ public class ItemForm {
 		this.author = source.getAuthor();
 		this.publisher = source.getPublisher();
 		this.isbn = source.getIsbn();
-		this.imageUrl = source.getImageUrl();
+		this.imageUrl = source.getImageUri();
 		this.publishedTime = source.getPublishedTime();
 		this.isOnedayEligible = source.getIsOnedayEligible();
 		this.isFreshEligible = source.getIsFreshEligible();

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,11 @@
+# azure
+azure.keyvault.client-id=501df022-3551-480f-8139-e70294ce79e2
+azure.keyvault.enabled=true
+azure.keyvault.tenant-id=04608e41-ef04-4ef8-9210-1d20c6bb0ce5
+azure.keyvault.uri=https://doubleshop.vault.azure.net/
+azure.keyvault.secret-keys=mysql-datasource, mysql-username, mysql-password, redis-session-host, admin-key, s3-access-key, s3-secrete-key
+# logging level
+logging.level.org.springframework=warn
+# JPA
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.show-sql=false

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -3,7 +3,7 @@ azure.keyvault.client-id=501df022-3551-480f-8139-e70294ce79e2
 azure.keyvault.enabled=true
 azure.keyvault.tenant-id=04608e41-ef04-4ef8-9210-1d20c6bb0ce5
 azure.keyvault.uri=https://doubleshop.vault.azure.net/
-azure.keyvault.secret-keys=mysql-datasource, mysql-username, mysql-password, redis-session-host, admin-key, s3-access-key, s3-secrete-key
+azure.keyvault.secret-keys=mysql-datasource, mysql-username, mysql-password, redis-session-host, admin-key, s3-access-key, s3-secrete-key, s3-region, s3-url, s3-bucketName
 # logging level
 logging.level.org.springframework=warn
 # JPA


### PR DESCRIPTION
- 상품 카테고리와 같이, 상품을 검색하는데, 거의 무조건 카테고리 스키마의 레코드를 검색.
- 서비스 특성상 카테고리는 write가 거의 없으며, 주로 read를 활용하기 때문에, 굳이 db 서버를 통해, 검색할 필요없이, 내부 캐시에 저장하여, 트랜잭션의 락 대기시간을 조금이라도 줄여보고자 함.