### PR TITLE
Hotfix: 인증 api 수정 (#80) 작업 테스트 서버에 배포

### DIFF
--- a/src/main/java/com/project/doubleshop/web/config/security/SimpleAuthenticationProvider.java
+++ b/src/main/java/com/project/doubleshop/web/config/security/SimpleAuthenticationProvider.java
@@ -71,14 +71,13 @@ public class SimpleAuthenticationProvider implements AuthenticationProvider {
 			SimpleAuthenticationToken authenticated =
 				new SimpleAuthenticationToken(member.getId(), null, createAuthorityList(Role.USER.value()));
 
-			Date now = new Date();
+			long now = System.nanoTime();
 			int expirySeconds = simpleTokenConfigurer.getExpirySeconds();
-
-			// 세션 서버 선택이 확정되면, 코드 변경.
+			
 			String tokenKey = UUID.randomUUID().toString();
 			String authClientAddress = IPUtils.getClientIpAddress(httpServletRequest);
 			SimpleToken tokenValue = new SimpleToken(member.getId(), member.getUserId(), member.getName(),
-				member.getEmail(), now, new Date(now.getTime() + expirySeconds * 1000L), authClientAddress, new String[] {Role.USER.value()});
+				member.getEmail(), now, now + expirySeconds * 1_000_000_000L, authClientAddress, new String[] {Role.USER.value()});
 
 			tokenService.saveSession(tokenKey, tokenValue);
 			authenticated.setDetails(new AuthenticationResult(tokenKey, tokenValue));

--- a/src/main/java/com/project/doubleshop/web/config/security/SimpleAuthenticationTokenFilter.java
+++ b/src/main/java/com/project/doubleshop/web/config/security/SimpleAuthenticationTokenFilter.java
@@ -75,6 +75,7 @@ public class SimpleAuthenticationTokenFilter extends GenericFilterBean {
 						String email = currentToken.getEmail();
 						String tokenIp = currentToken.getClientIp();
 						String clientIp = IPUtils.getClientIpAddress(request);
+						log.debug("Current client ip address : {}", clientIp);
 
 						List<GrantedAuthority> authorities = obtainAuthorities(currentToken);
 
@@ -107,12 +108,12 @@ public class SimpleAuthenticationTokenFilter extends GenericFilterBean {
 	}
 
 	private boolean isExpired(SimpleToken token) {
-		long remain  = token.getExpiredAt().getTime() - System.currentTimeMillis();
+		long remain  = token.getExpiredAt() - System.nanoTime();
 		return remain < 0;
 	}
 
 	private boolean canRefresh(SimpleToken token, int seconds) {
-		long remain = token.getExpiredAt().getTime() - System.currentTimeMillis();
-		return remain < seconds * 1000L;
+		long remain = token.getExpiredAt() - System.nanoTime();
+		return remain < seconds * 1_000_000_000L;
 	}
 }

--- a/src/main/java/com/project/doubleshop/web/config/security/SimpleToken.java
+++ b/src/main/java/com/project/doubleshop/web/config/security/SimpleToken.java
@@ -22,17 +22,16 @@ public class SimpleToken {
 
 	private String email;
 
-	private Date issuedAt;
+	private Long issuedAt;
 
-	private Date expiredAt;
+	private Long expiredAt;
 
 	private String clientIp;
 
 	private String[] roles;
 
 	public void resetExpiry(int expirySeconds) {
-		Date now = new Date();
-		this.expiredAt = new Date(now.getTime() + expirySeconds * 1000L);
+		this.expiredAt = System.currentTimeMillis() + expirySeconds * 1_000_000_000L;
 	}
 
 	public void addRole(Role role) {


### PR DESCRIPTION
* Fix: java.util.Date를 long으로 변경

java.util.Date가 시스템의 timezone에 따라 다르게 입력된다.
그래서, System.currentTimeMills() 자체가 UTC 기준으로 입력이 된다는 점을 참고하여,
해당 밀리초의 값 그대로를 저장하기로 함

* Fix: 토큰 유효기간을 nanoseconds 단위로 변경

wall-clock time의 제약을 가진 `System.currentTimeMillis()`는 시스템의 시간 조작에 따라, time-jump가 발생할 가능성이 있다.